### PR TITLE
Instructions now spend cycles at the read/write level

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 IndentWidth: 4
 UseTab: Never
-ColumnLimit: 100 # Maximimum line length
+ColumnLimit: 110 # Maximimum line length
 SortIncludes: false
 IncludeBlocks: Preserve
 

--- a/include/bus.h
+++ b/include/bus.h
@@ -29,7 +29,7 @@ class Bus
     void LoadCartridge( std::shared_ptr<Cartridge> cartridge );
 
     // PPU sync helper
-    void SyncPPU( u64 cycles );
+    void TickPPU();
 
     // Is test mode
     [[nodiscard]] bool IsTestMode() const;

--- a/include/cartridge.h
+++ b/include/cartridge.h
@@ -64,8 +64,7 @@ class Cartridge
 
     // PRG RAM: Program RAM, also known as Save RAM (SRAM) or Work RAM sometimes
     // Its usage is determined by the mapper
-    array<u8, 0x1FFF>
-        _prg_ram{}; // 8KiB PRG RAM, also known as Save RAM (SRAM) or Work RAM sometimes
+    array<u8, 0x1FFF> _prg_ram{}; // 8KiB PRG RAM, also known as Save RAM (SRAM) or Work RAM sometimes
 
     // Expansion ROM
     // Almost never used, but here it is anyway.

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -39,8 +39,12 @@ class CPU
 
     // public cpu methods
     void               Reset();
+    void               DecodeExecute();
     void               Tick();
     [[nodiscard]] auto Read( u16 address ) const -> u8;
+    [[nodiscard]] auto ReadAndTick( u16 address ) -> u8;
+    void               Write( u16 address, u8 data ) const;
+    void               WriteAndTick( u16 address, u8 data );
 
     // public helpers
     std::string LogLineAtPC( bool verbose = true );
@@ -52,24 +56,29 @@ class CPU
   private:
     friend class CPUTestFixture; // Sometimes used for testing private methods
 
-    Bus *_bus;         // Pointer to the Bus class
-    bool _imp = false; // Implicit addressing mode flag
-    bool _did_vblank = false;
+    Bus *_bus; // Pointer to the Bus class
+
+    // Heper flags
+    bool        _did_vblank = false;
+    bool        _is_write_modify = false;
+    u8          _opcode = 0x00;
+    std::string _instruction_name;
+    std::string _addr_mode;
 
     // Registers
-    u16 _pc = 0x0000; // Program counter (PC)
-    u8  _a = 0x00;    // Accumulator register (A)
-    u8  _x = 0x00;    // X register
-    u8  _y = 0x00;    // Y register
-    u8  _s = 0xFD;    // Stack pointer (SP)
-    u8  _p =
-        0x00 | Unused; // Status register (P), per the specs, the unused flag should always be set
-    u64 _cycles = 0;   // Number of cycles
+    u16 _pc = 0x0000;       // Program counter (PC)
+    u8  _a = 0x00;          // Accumulator register (A)
+    u8  _x = 0x00;          // X register
+    u8  _y = 0x00;          // Y register
+    u8  _s = 0xFD;          // Stack pointer (SP)
+    u8  _p = 0x00 | Unused; // Status register (P), per the specs, the unused flag should always be set
+    u64 _cycles = 0;        // Number of cycles
 
     // Instruction data
     struct InstructionData
     {
         std::string name;                        // Instruction mnemonic (e.g. LDA, STA)
+        std::string addr_mode;                   // Addressing mode mnemonic (e.g. ABS, ZPG)
         void ( CPU::*instructionMethod )( u16 ); // Pointer to the instruction helper method
         u16 ( CPU::*addressingModeMethod )();    // Pointer to the address mode helper method
         u8 cycles;                               // Number of cycles the instruction takes
@@ -78,6 +87,8 @@ class CPU
         // cases the extra cycle is not taken if the operation is a read. This will be set
         // selectively for a handful of opcodes, but otherwise will be set to true by default
         bool pageCrossPenalty = true;
+        bool isWriteModify = false; // Write/modify instructions use a dummy read before writing,
+                                    // spending an extra cycle
     };
 
     bool _currentPageCrossPenalty = true;
@@ -87,9 +98,6 @@ class CPU
 
     // Fetch/decode/execute cycle
     [[nodiscard]] u8 Fetch();
-
-    // Read/write methods
-    void Write( u16 address, u8 data ) const;
 
     /*
     ################################################################
@@ -120,7 +128,7 @@ class CPU
 
     // LDA, LDX, and LDY helper
     void LoadRegister( u16 address, u8 &reg );
-    void StoreRegister( u16 address, u8 reg ) const;
+    void StoreRegister( u16 address, u8 reg );
 
     // Branch helper
     void BranchOnStatus( u16 offsetAddress, u8 flag, bool isSet );
@@ -244,6 +252,7 @@ class CPU
     ||                                                            ||
     ################################################################
     */
+    void NOP2( u16 address );
     void JAM( u16 address );
     void SLO( u16 address );
     void RLA( u16 address );

--- a/include/ppu.h
+++ b/include/ppu.h
@@ -51,9 +51,6 @@ class PPU
     void WritePatternTable( u16 addr, u8 data );
     void WriteNameTable( u16 addr, u8 data );
     u16  ResolveNameTableAddress( u16 addr );
-
-    void SyncPPU( u64 current_cpu_cycles );
-
     void Tick();
 
   private:

--- a/include/utils.h
+++ b/include/utils.h
@@ -2,9 +2,13 @@
 
 #include <string>
 #include <cstdint>
+#include <unordered_set>
+#include <sstream>
 
 using u8 = std::uint8_t;
 using u16 = std::uint16_t;
+
+using namespace std;
 
 namespace utils
 {
@@ -23,4 +27,71 @@ inline std::string toHex( u16 num, u8 width = 4 )
     return hex_str;
 }
 
+inline const std::unordered_set<std::string> &getAddrModeSet()
+{
+    static const std::unordered_set<std::string> addr_mode_set = {
+        "IMP", "IMM", "ZPG", "ZPGX", "ZPGY", "ABS", "ABSX", "ABSY", "IND", "INDX", "INDY", "REL" };
+    return addr_mode_set;
+}
+
+inline bool isValidAddrModeStr( const std::string &addr_mode )
+{
+    const auto &addr_mode_set = getAddrModeSet();
+    return addr_mode_set.find( addr_mode ) != addr_mode_set.end();
+}
+
+inline std::string getAvailableAddrModes()
+{
+    const auto        &addr_mode_set = getAddrModeSet();
+    std::ostringstream oss;
+    for ( const auto &addr_mode : addr_mode_set )
+    {
+        oss << addr_mode << ", ";
+    }
+    std::string result = oss.str();
+    // Remove trailing comma and space
+    if ( !result.empty() )
+    {
+        result.pop_back();
+        result.pop_back();
+    }
+    return result;
+}
+
+inline const std::unordered_set<std::string> &getOpcodeNameSet()
+{
+    static const std::unordered_set<std::string> name_set = {
+        "ADC", "AND", "ASL", "BCC", "BCS", "BEQ", "BIT", "BMI", "BNE", "BPL", "BRK", "BVC", "BVS", "CLC",
+        "CLD", "CLI", "CLV", "CMP", "CPX", "CPY", "DEC", "DEX", "DEY", "EOR", "INC", "INX", "INY", "JMP",
+        "JSR", "LDA", "LDX", "LDY", "LSR", "NOP", "ORA", "PHA", "PHP", "PLA", "PLP", "ROL", "ROR", "RTI",
+        "RTS", "SBC", "SEC", "SED", "SEI", "STA", "STX", "STY", "TAX", "TAY", "TSX", "TXA", "TXS", "TYA",
+        // Illegal
+        "*ALR", "*ANC", "*ARR", "*DCP", "*ISC", "*JAM", "*LAX", "*LXA", "*NOP", "*RLA", "*RRA", "*SAX",
+        "*SBC", "*SBX", "*SLO", "*SRE" };
+    return name_set;
+}
+
+inline bool isValidOpcodeName( const std::string &name )
+{
+    const auto &name_set = getOpcodeNameSet();
+    return name_set.find( name ) != name_set.end();
+}
+
+inline std::string getAvailableOpcodeNames()
+{
+    const auto        &name_set = getOpcodeNameSet();
+    std::ostringstream oss;
+    for ( const auto &name : name_set )
+    {
+        oss << name << ", ";
+    }
+    std::string result = oss.str();
+    // Remove trailing comma and space
+    if ( !result.empty() )
+    {
+        result.pop_back();
+        result.pop_back();
+    }
+    return result;
+}
 } // namespace utils

--- a/src/bus.cpp
+++ b/src/bus.cpp
@@ -91,12 +91,9 @@ void Bus::Write( const u16 address, const u8 data )
     std::cout << "Unhandled write to address: " << std::hex << address << "\n";
 }
 
-void Bus::LoadCartridge( std::shared_ptr<Cartridge> cartridge )
-{
-    _cartridge = std::move( cartridge );
-}
+void Bus::LoadCartridge( std::shared_ptr<Cartridge> cartridge ) { _cartridge = std::move( cartridge ); }
 
-void Bus::SyncPPU( u64 cycles ) { _ppu->SyncPPU( cycles ); }
+void Bus::TickPPU() { _ppu->Tick(); }
 
 [[nodiscard]] bool Bus::IsTestMode() const { return _use_flat_memory; }
 [[nodiscard]] u16  Bus::GetPpuCycles() const { return _ppu->GetCycle(); }

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1,11 +1,9 @@
-// cpu.cpp
+// cpu.cp
 
 #include "cpu.h"
 #include "bus.h"
-#include <cstddef>
 #include "utils.h"
 #include <cstdint>
-#include <iostream>
 #include <stdexcept>
 #include <string>
 
@@ -21,218 +19,204 @@ CPU::CPU( Bus *bus ) : _bus( bus ), _opcodeTable{}
     */
 
     // NOP
-    _opcodeTable[0xEA] = InstructionData{ "NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xEA] = InstructionData{ "NOP", "IMM", &CPU::NOP, &CPU::IMP, 2, 1 };
 
     // LDA
-    _opcodeTable[0xA9] = InstructionData{ "LDA_Immediate", &CPU::LDA, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xA5] = InstructionData{ "LDA_ZeroPage", &CPU::LDA, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xB5] = InstructionData{ "LDA_ZeroPageX", &CPU::LDA, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xAD] = InstructionData{ "LDA_Absolute", &CPU::LDA, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xBD] = InstructionData{ "LDA_AbsoluteX", &CPU::LDA, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0xB9] = InstructionData{ "LDA_AbsoluteY", &CPU::LDA, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0xA1] = InstructionData{ "LDA_IndirectX", &CPU::LDA, &CPU::INDX, 6, 2 };
-    _opcodeTable[0xB1] = InstructionData{ "LDA_IndirectY", &CPU::LDA, &CPU::INDY, 5, 2 };
+    _opcodeTable[0xA9] = InstructionData{ "LDA", "IMM", &CPU::LDA, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xA5] = InstructionData{ "LDA", "ZPG", &CPU::LDA, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xB5] = InstructionData{ "LDA", "ZPGX", &CPU::LDA, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xAD] = InstructionData{ "LDA", "ABS", &CPU::LDA, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xBD] = InstructionData{ "LDA", "ABSX", &CPU::LDA, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xB9] = InstructionData{ "LDA", "ABSY", &CPU::LDA, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0xA1] = InstructionData{ "LDA", "INDX", &CPU::LDA, &CPU::INDX, 6, 2 };
+    _opcodeTable[0xB1] = InstructionData{ "LDA", "INDY", &CPU::LDA, &CPU::INDY, 5, 2 };
 
     // LDX
-    _opcodeTable[0xA2] = InstructionData{ "LDX_Immediate", &CPU::LDX, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xA6] = InstructionData{ "LDX_ZeroPage", &CPU::LDX, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xB6] = InstructionData{ "LDX_ZeroPageY", &CPU::LDX, &CPU::ZPGY, 4, 2 };
-    _opcodeTable[0xAE] = InstructionData{ "LDX_Absolute", &CPU::LDX, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xBE] = InstructionData{ "LDX_AbsoluteY", &CPU::LDX, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0xA2] = InstructionData{ "LDX", "IMM", &CPU::LDX, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xA6] = InstructionData{ "LDX", "ZPG", &CPU::LDX, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xB6] = InstructionData{ "LDX", "ZPGY", &CPU::LDX, &CPU::ZPGY, 4, 2, true, true };
+    _opcodeTable[0xAE] = InstructionData{ "LDX", "ABS", &CPU::LDX, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xBE] = InstructionData{ "LDX", "ABSY", &CPU::LDX, &CPU::ABSY, 4, 3 };
 
     // LDY
-    _opcodeTable[0xA0] = InstructionData{ "LDY_Immediate", &CPU::LDY, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xA4] = InstructionData{ "LDY_ZeroPage", &CPU::LDY, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xB4] = InstructionData{ "LDY_ZeroPageX", &CPU::LDY, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xAC] = InstructionData{ "LDY_Absolute", &CPU::LDY, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xBC] = InstructionData{ "LDY_AbsoluteX", &CPU::LDY, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xA0] = InstructionData{ "LDY", "IMM", &CPU::LDY, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xA4] = InstructionData{ "LDY", "ZPG", &CPU::LDY, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xB4] = InstructionData{ "LDY", "ZPGX", &CPU::LDY, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xAC] = InstructionData{ "LDY", "ABS", &CPU::LDY, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xBC] = InstructionData{ "LDY", "ABSX", &CPU::LDY, &CPU::ABSX, 4, 3 };
 
     // STA
-    _opcodeTable[0x85] = InstructionData{ "STA_ZeroPage", &CPU::STA, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x95] = InstructionData{ "STA_ZeroPageX", &CPU::STA, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x8D] = InstructionData{ "STA_Absolute", &CPU::STA, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x9D] = InstructionData{ "STA_AbsoluteX", &CPU::STA, &CPU::ABSX, 5, 3, false };
-    _opcodeTable[0x99] = InstructionData{ "STA_AbsoluteY", &CPU::STA, &CPU::ABSY, 5, 3, false };
-    _opcodeTable[0x81] = InstructionData{ "STA_IndirectX", &CPU::STA, &CPU::INDX, 6, 2, false };
-    _opcodeTable[0x91] = InstructionData{ "STA_IndirectY", &CPU::STA, &CPU::INDY, 6, 2, false };
+    _opcodeTable[0x85] = InstructionData{ "STA", "ZPG", &CPU::STA, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x95] = InstructionData{ "STA", "ZPGX", &CPU::STA, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x8D] = InstructionData{ "STA", "ABS", &CPU::STA, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x9D] = InstructionData{ "STA", "ABSX", &CPU::STA, &CPU::ABSX, 5, 3, false, true };
+    _opcodeTable[0x99] = InstructionData{ "STA", "ABSY", &CPU::STA, &CPU::ABSY, 5, 3, false, true };
+    _opcodeTable[0x81] = InstructionData{ "STA", "INDX", &CPU::STA, &CPU::INDX, 6, 2, false };
+    _opcodeTable[0x91] = InstructionData{ "STA", "INDY", &CPU::STA, &CPU::INDY, 6, 2, false, true };
 
     // STX
-    _opcodeTable[0x86] = InstructionData{ "STX_ZeroPage", &CPU::STX, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x96] = InstructionData{ "STX_ZeroPageY", &CPU::STX, &CPU::ZPGY, 4, 2 };
-    _opcodeTable[0x8E] = InstructionData{ "STX_Absolute", &CPU::STX, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x86] = InstructionData{ "STX", "ZPG", &CPU::STX, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x96] = InstructionData{ "STX", "ZPGY", &CPU::STX, &CPU::ZPGY, 4, 2, true, true };
+    _opcodeTable[0x8E] = InstructionData{ "STX", "ABS", &CPU::STX, &CPU::ABS, 4, 3 };
 
     // STY
-    _opcodeTable[0x84] = InstructionData{ "STY_ZeroPage", &CPU::STY, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x94] = InstructionData{ "STY_ZeroPageX", &CPU::STY, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x8C] = InstructionData{ "STY_Absolute", &CPU::STY, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x84] = InstructionData{ "STY", "ZPG", &CPU::STY, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x94] = InstructionData{ "STY", "ZPGX", &CPU::STY, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x8C] = InstructionData{ "STY", "ABS", &CPU::STY, &CPU::ABS, 4, 3 };
 
     // ADC
-    _opcodeTable[0x69] = InstructionData{ "ADC_Immediate", &CPU::ADC, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x65] = InstructionData{ "ADC_ZeroPage", &CPU::ADC, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x75] = InstructionData{ "ADC_ZeroPageX", &CPU::ADC, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x6D] = InstructionData{ "ADC_Absolute", &CPU::ADC, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x7D] = InstructionData{ "ADC_AbsoluteX", &CPU::ADC, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x79] = InstructionData{ "ADC_AbsoluteY", &CPU::ADC, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0x61] = InstructionData{ "ADC_IndirectX", &CPU::ADC, &CPU::INDX, 6, 2 };
-    _opcodeTable[0x71] = InstructionData{ "ADC_IndirectY", &CPU::ADC, &CPU::INDY, 5, 2 };
+    _opcodeTable[0x69] = InstructionData{ "ADC", "IMM", &CPU::ADC, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x65] = InstructionData{ "ADC", "ZPG", &CPU::ADC, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x75] = InstructionData{ "ADC", "ZPGX", &CPU::ADC, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x6D] = InstructionData{ "ADC", "ABS", &CPU::ADC, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x7D] = InstructionData{ "ADC", "ABSX", &CPU::ADC, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x79] = InstructionData{ "ADC", "ABSY", &CPU::ADC, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0x61] = InstructionData{ "ADC", "INDX", &CPU::ADC, &CPU::INDX, 6, 2 };
+    _opcodeTable[0x71] = InstructionData{ "ADC", "INDY", &CPU::ADC, &CPU::INDY, 5, 2 };
 
     // SBC
-    _opcodeTable[0xE9] = InstructionData{ "SBC_Immediate", &CPU::SBC, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xE5] = InstructionData{ "SBC_ZeroPage", &CPU::SBC, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xF5] = InstructionData{ "SBC_ZeroPageX", &CPU::SBC, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xED] = InstructionData{ "SBC_Absolute", &CPU::SBC, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xFD] = InstructionData{ "SBC_AbsoluteX", &CPU::SBC, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0xF9] = InstructionData{ "SBC_AbsoluteY", &CPU::SBC, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0xE1] = InstructionData{ "SBC_IndirectX", &CPU::SBC, &CPU::INDX, 6, 2 };
-    _opcodeTable[0xF1] = InstructionData{ "SBC_IndirectY", &CPU::SBC, &CPU::INDY, 5, 2 };
+    _opcodeTable[0xE9] = InstructionData{ "SBC", "IMM", &CPU::SBC, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xE5] = InstructionData{ "SBC", "ZPG", &CPU::SBC, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xF5] = InstructionData{ "SBC", "ZPGX", &CPU::SBC, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xED] = InstructionData{ "SBC", "ABS", &CPU::SBC, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xFD] = InstructionData{ "SBC", "ABSX", &CPU::SBC, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xF9] = InstructionData{ "SBC", "ABSY", &CPU::SBC, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0xE1] = InstructionData{ "SBC", "INDX", &CPU::SBC, &CPU::INDX, 6, 2 };
+    _opcodeTable[0xF1] = InstructionData{ "SBC", "INDY", &CPU::SBC, &CPU::INDY, 5, 2 };
 
     // INC
-    _opcodeTable[0xE6] = InstructionData{ "INC_ZeroPage", &CPU::INC, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0xF6] = InstructionData{ "INC_ZeroPageX", &CPU::INC, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0xEE] = InstructionData{ "INC_Absolute", &CPU::INC, &CPU::ABS, 6, 3 };
-    _opcodeTable[0xFE] = InstructionData{ "INC_AbsoluteX", &CPU::INC, &CPU::ABSX, 7, 3, false };
+    _opcodeTable[0xE6] = InstructionData{ "INC", "ZPG", &CPU::INC, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0xF6] = InstructionData{ "INC", "ZPGX", &CPU::INC, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0xEE] = InstructionData{ "INC", "ABS", &CPU::INC, &CPU::ABS, 6, 3 };
+    _opcodeTable[0xFE] = InstructionData{ "INC", "ABSX", &CPU::INC, &CPU::ABSX, 7, 3, false, true };
 
     // DEC
-    _opcodeTable[0xC6] = InstructionData{ "DEC_ZeroPage", &CPU::DEC, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0xD6] = InstructionData{ "DEC_ZeroPageX", &CPU::DEC, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0xCE] = InstructionData{ "DEC_Absolute", &CPU::DEC, &CPU::ABS, 6, 3 };
-    _opcodeTable[0xDE] = InstructionData{ "DEC_AbsoluteX", &CPU::DEC, &CPU::ABSX, 7, 3, false };
+    _opcodeTable[0xC6] = InstructionData{ "DEC", "ZPG", &CPU::DEC, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0xD6] = InstructionData{ "DEC", "ZPGX", &CPU::DEC, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0xCE] = InstructionData{ "DEC", "ABS", &CPU::DEC, &CPU::ABS, 6, 3 };
+    _opcodeTable[0xDE] = InstructionData{ "DEC", "ABSX", &CPU::DEC, &CPU::ABSX, 7, 3, false, true };
 
     // INX, INY, DEX, DEY
-    _opcodeTable[0xE8] = InstructionData{ "INX_Implied", &CPU::INX, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xC8] = InstructionData{ "INY_Implied", &CPU::INY, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xCA] = InstructionData{ "DEX_Implied", &CPU::DEX, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x88] = InstructionData{ "DEY_Implied", &CPU::DEY, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xE8] = InstructionData{ "INX", "IMP", &CPU::INX, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xC8] = InstructionData{ "INY", "IMP", &CPU::INY, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xCA] = InstructionData{ "DEX", "IMP", &CPU::DEX, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x88] = InstructionData{ "DEY", "IMP", &CPU::DEY, &CPU::IMP, 2, 1 };
 
     // CLC
-    _opcodeTable[0x18] = InstructionData{ "CLC_Implied", &CPU::CLC, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x58] = InstructionData{ "CLI_Implied", &CPU::CLI, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xD8] = InstructionData{ "CLD_Implied", &CPU::CLD, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xB8] = InstructionData{ "CLV_Implied", &CPU::CLV, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x18] = InstructionData{ "CLC", "IMP", &CPU::CLC, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x58] = InstructionData{ "CLI", "IMP", &CPU::CLI, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xD8] = InstructionData{ "CLD", "IMP", &CPU::CLD, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xB8] = InstructionData{ "CLV", "IMP", &CPU::CLV, &CPU::IMP, 2, 1 };
 
-    _opcodeTable[0x38] = InstructionData{ "SEC_Implied", &CPU::SEC, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x78] = InstructionData{ "SEI_Implied", &CPU::SEI, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xF8] = InstructionData{ "SED_Implied", &CPU::SED, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x38] = InstructionData{ "SEC", "IMP", &CPU::SEC, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x78] = InstructionData{ "SEI", "IMP", &CPU::SEI, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xF8] = InstructionData{ "SED", "IMP", &CPU::SED, &CPU::IMP, 2, 1 };
 
     // Branch
-    _opcodeTable[0x10] = InstructionData{ "BPL_Relative", &CPU::BPL, &CPU::REL, 2, 2 };
-    _opcodeTable[0x30] = InstructionData{ "BMI_Relative", &CPU::BMI, &CPU::REL, 2, 2 };
-    _opcodeTable[0x50] = InstructionData{ "BVC_Relative", &CPU::BVC, &CPU::REL, 2, 2 };
-    _opcodeTable[0x70] = InstructionData{ "BVS_Relative", &CPU::BVS, &CPU::REL, 2, 2 };
-    _opcodeTable[0x90] = InstructionData{ "BCC_Relative", &CPU::BCC, &CPU::REL, 2, 2 };
-    _opcodeTable[0xB0] = InstructionData{ "BCS_Relative", &CPU::BCS, &CPU::REL, 2, 2 };
-    _opcodeTable[0xD0] = InstructionData{ "BNE_Relative", &CPU::BNE, &CPU::REL, 2, 2 };
-    _opcodeTable[0xF0] = InstructionData{ "BEQ_Relative", &CPU::BEQ, &CPU::REL, 2, 2 };
+    _opcodeTable[0x10] = InstructionData{ "BPL", "REL", &CPU::BPL, &CPU::REL, 2, 2 };
+    _opcodeTable[0x30] = InstructionData{ "BMI", "REL", &CPU::BMI, &CPU::REL, 2, 2 };
+    _opcodeTable[0x50] = InstructionData{ "BVC", "REL", &CPU::BVC, &CPU::REL, 2, 2 };
+    _opcodeTable[0x70] = InstructionData{ "BVS", "REL", &CPU::BVS, &CPU::REL, 2, 2 };
+    _opcodeTable[0x90] = InstructionData{ "BCC", "REL", &CPU::BCC, &CPU::REL, 2, 2 };
+    _opcodeTable[0xB0] = InstructionData{ "BCS", "REL", &CPU::BCS, &CPU::REL, 2, 2 };
+    _opcodeTable[0xD0] = InstructionData{ "BNE", "REL", &CPU::BNE, &CPU::REL, 2, 2 };
+    _opcodeTable[0xF0] = InstructionData{ "BEQ", "REL", &CPU::BEQ, &CPU::REL, 2, 2 };
 
     // CMP, CPX, CPY
-    _opcodeTable[0xC9] = InstructionData{ "CMP_Immediate", &CPU::CMP, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xC5] = InstructionData{ "CMP_ZeroPage", &CPU::CMP, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xD5] = InstructionData{ "CMP_ZeroPageX", &CPU::CMP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xCD] = InstructionData{ "CMP_Absolute", &CPU::CMP, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xDD] = InstructionData{ "CMP_AbsoluteX", &CPU::CMP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0xD9] = InstructionData{ "CMP_AbsoluteY", &CPU::CMP, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0xC1] = InstructionData{ "CMP_IndirectX", &CPU::CMP, &CPU::INDX, 6, 2 };
-    _opcodeTable[0xD1] = InstructionData{ "CMP_IndirectY", &CPU::CMP, &CPU::INDY, 5, 2 };
-    _opcodeTable[0xE0] = InstructionData{ "CPX_Immediate", &CPU::CPX, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xE4] = InstructionData{ "CPX_ZeroPage", &CPU::CPX, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xEC] = InstructionData{ "CPX_Absolute", &CPU::CPX, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xC0] = InstructionData{ "CPY_Immediate", &CPU::CPY, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xC4] = InstructionData{ "CPY_ZeroPage", &CPU::CPY, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xCC] = InstructionData{ "CPY_Absolute", &CPU::CPY, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xC9] = InstructionData{ "CMP", "IMM", &CPU::CMP, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xC5] = InstructionData{ "CMP", "ZPG", &CPU::CMP, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xD5] = InstructionData{ "CMP", "ZPGX", &CPU::CMP, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xCD] = InstructionData{ "CMP", "ABS", &CPU::CMP, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xDD] = InstructionData{ "CMP", "ABSX", &CPU::CMP, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xD9] = InstructionData{ "CMP", "ABSY", &CPU::CMP, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0xC1] = InstructionData{ "CMP", "INDX", &CPU::CMP, &CPU::INDX, 6, 2 };
+    _opcodeTable[0xD1] = InstructionData{ "CMP", "INDY", &CPU::CMP, &CPU::INDY, 5, 2 };
+    _opcodeTable[0xE0] = InstructionData{ "CPX", "IMM", &CPU::CPX, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xE4] = InstructionData{ "CPX", "ZPG", &CPU::CPX, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xEC] = InstructionData{ "CPX", "ABS", &CPU::CPX, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xC0] = InstructionData{ "CPY", "IMM", &CPU::CPY, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xC4] = InstructionData{ "CPY", "ZPG", &CPU::CPY, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xCC] = InstructionData{ "CPY", "ABS", &CPU::CPY, &CPU::ABS, 4, 3 };
 
     // PHA, PHP, PLA, PLP, TSX, TXS
-    _opcodeTable[0x48] = InstructionData{ "PHA_Implied", &CPU::PHA, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x08] = InstructionData{ "PHP_Implied", &CPU::PHP, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x68] = InstructionData{ "PLA_Implied", &CPU::PLA, &CPU::IMP, 4, 1 };
-    _opcodeTable[0x28] = InstructionData{ "PLP_Implied", &CPU::PLP, &CPU::IMP, 4, 1 };
-    _opcodeTable[0xBA] = InstructionData{ "TSX_Implied", &CPU::TSX, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x9A] = InstructionData{ "TXS_Implied", &CPU::TXS, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x48] = InstructionData{ "PHA", "IMP", &CPU::PHA, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x08] = InstructionData{ "PHP", "IMP", &CPU::PHP, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x68] = InstructionData{ "PLA", "IMP", &CPU::PLA, &CPU::IMP, 4, 1 };
+    _opcodeTable[0x28] = InstructionData{ "PLP", "IMP", &CPU::PLP, &CPU::IMP, 4, 1 };
+    _opcodeTable[0xBA] = InstructionData{ "TSX", "IMP", &CPU::TSX, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x9A] = InstructionData{ "TXS", "IMP", &CPU::TXS, &CPU::IMP, 2, 1 };
 
     // ASL, LSR
-    _opcodeTable[0x0A] = InstructionData{ "ASL_Implied", &CPU::ASL, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x06] = InstructionData{ "ASL_ZeroPage", &CPU::ASL, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x16] = InstructionData{ "ASL_ZeroPageX", &CPU::ASL, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x0E] = InstructionData{ "ASL_Absolute", &CPU::ASL, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x1E] = InstructionData{ "ASL_AbsoluteX", &CPU::ASL, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0x4A] = InstructionData{ "LSR_Implied", &CPU::LSR, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x46] = InstructionData{ "LSR_ZeroPage", &CPU::LSR, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x56] = InstructionData{ "LSR_ZeroPageX", &CPU::LSR, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x4E] = InstructionData{ "LSR_Absolute", &CPU::LSR, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x5E] = InstructionData{ "LSR_AbsoluteX", &CPU::LSR, &CPU::ABSX, 7, 3, false };
+    _opcodeTable[0x0A] = InstructionData{ "ASL", "IMP", &CPU::ASL, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x06] = InstructionData{ "ASL", "ZPG", &CPU::ASL, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x16] = InstructionData{ "ASL", "ZPGX", &CPU::ASL, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x0E] = InstructionData{ "ASL", "ABS", &CPU::ASL, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x1E] = InstructionData{ "ASL", "ABSX", &CPU::ASL, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x4A] = InstructionData{ "LSR", "IMP", &CPU::LSR, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x46] = InstructionData{ "LSR", "ZPG", &CPU::LSR, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x56] = InstructionData{ "LSR", "ZPGX", &CPU::LSR, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x4E] = InstructionData{ "LSR", "ABS", &CPU::LSR, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x5E] = InstructionData{ "LSR", "ABSX", &CPU::LSR, &CPU::ABSX, 7, 3, false, true };
 
     // ROL, ROR
-    _opcodeTable[0x2A] = InstructionData{ "ROL_Implied", &CPU::ROL, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x26] = InstructionData{ "ROL_ZeroPage", &CPU::ROL, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x36] = InstructionData{ "ROL_ZeroPageX", &CPU::ROL, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x2E] = InstructionData{ "ROL_Absolute", &CPU::ROL, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x3E] = InstructionData{ "ROL_AbsoluteX", &CPU::ROL, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0x6A] = InstructionData{ "ROR_Implied", &CPU::ROR, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x66] = InstructionData{ "ROR_ZeroPage", &CPU::ROR, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x76] = InstructionData{ "ROR_ZeroPageX", &CPU::ROR, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x6E] = InstructionData{ "ROR_Absolute", &CPU::ROR, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x7E] = InstructionData{ "ROR_AbsoluteX", &CPU::ROR, &CPU::ABSX, 7, 3, false };
+    _opcodeTable[0x2A] = InstructionData{ "ROL", "IMP", &CPU::ROL, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x26] = InstructionData{ "ROL", "ZPG", &CPU::ROL, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x36] = InstructionData{ "ROL", "ZPGX", &CPU::ROL, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x2E] = InstructionData{ "ROL", "ABS", &CPU::ROL, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x3E] = InstructionData{ "ROL", "ABSX", &CPU::ROL, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x6A] = InstructionData{ "ROR", "IMP", &CPU::ROR, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x66] = InstructionData{ "ROR", "ZPG", &CPU::ROR, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x76] = InstructionData{ "ROR", "ZPGX", &CPU::ROR, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x6E] = InstructionData{ "ROR", "ABS", &CPU::ROR, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x7E] = InstructionData{ "ROR", "ABSX", &CPU::ROR, &CPU::ABSX, 7, 3, false, true };
 
     // JMP JSR, RTS, RTI, BRK
-    _opcodeTable[0x4C] = InstructionData{ "JMP_Absolute", &CPU::JMP, &CPU::ABS, 3, 3 };
-    _opcodeTable[0x6C] = InstructionData{ "JMP_Indirect", &CPU::JMP, &CPU::IND, 5, 3 };
-    _opcodeTable[0x20] = InstructionData{ "JSR_Absolute", &CPU::JSR, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x60] = InstructionData{ "RTS_Implied", &CPU::RTS, &CPU::IMP, 6, 1 };
-    _opcodeTable[0x40] = InstructionData{ "RTI_Implied", &CPU::RTI, &CPU::IMP, 6, 1 };
-    _opcodeTable[0x00] = InstructionData{ "BRK_Implied", &CPU::BRK, &CPU::IMP, 7, 1 };
+    _opcodeTable[0x4C] = InstructionData{ "JMP", "ABS", &CPU::JMP, &CPU::ABS, 3, 3 };
+    _opcodeTable[0x6C] = InstructionData{ "JMP", "IND", &CPU::JMP, &CPU::IND, 5, 3 };
+    _opcodeTable[0x20] = InstructionData{ "JSR", "ABS", &CPU::JSR, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x60] = InstructionData{ "RTS", "IMP", &CPU::RTS, &CPU::IMP, 6, 1 };
+    _opcodeTable[0x40] = InstructionData{ "RTI", "IMP", &CPU::RTI, &CPU::IMP, 6, 1 };
+    _opcodeTable[0x00] = InstructionData{ "BRK", "IMP", &CPU::BRK, &CPU::IMP, 7, 1 };
 
     // AND
-    _opcodeTable[0x29] = InstructionData{ "AND_Immediate", &CPU::AND, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x25] = InstructionData{ "AND_ZeroPage", &CPU::AND, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x35] = InstructionData{ "AND_ZeroPageX", &CPU::AND, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x2D] = InstructionData{ "AND_Absolute", &CPU::AND, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x3D] = InstructionData{ "AND_AbsoluteX", &CPU::AND, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x39] = InstructionData{ "AND_AbsoluteY", &CPU::AND, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0x21] = InstructionData{ "AND_IndirectX", &CPU::AND, &CPU::INDX, 6, 2 };
-    _opcodeTable[0x31] = InstructionData{ "AND_IndirectY", &CPU::AND, &CPU::INDY, 5, 2 };
+    _opcodeTable[0x29] = InstructionData{ "AND", "IMM", &CPU::AND, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x25] = InstructionData{ "AND", "ZPG", &CPU::AND, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x35] = InstructionData{ "AND", "ZPGX", &CPU::AND, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x2D] = InstructionData{ "AND", "ABS", &CPU::AND, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x3D] = InstructionData{ "AND", "ABSX", &CPU::AND, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x39] = InstructionData{ "AND", "ABSY", &CPU::AND, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0x21] = InstructionData{ "AND", "INDX", &CPU::AND, &CPU::INDX, 6, 2 };
+    _opcodeTable[0x31] = InstructionData{ "AND", "INDY", &CPU::AND, &CPU::INDY, 5, 2 };
 
     // ORA
-    _opcodeTable[0x09] = InstructionData{ "ORA_Immediate", &CPU::ORA, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x05] = InstructionData{ "ORA_ZeroPage", &CPU::ORA, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x15] = InstructionData{ "ORA_ZeroPageX", &CPU::ORA, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x0D] = InstructionData{ "ORA_Absolute", &CPU::ORA, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x1D] = InstructionData{ "ORA_AbsoluteX", &CPU::ORA, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x19] = InstructionData{ "ORA_AbsoluteY", &CPU::ORA, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0x01] = InstructionData{ "ORA_IndirectX", &CPU::ORA, &CPU::INDX, 6, 2 };
-    _opcodeTable[0x11] = InstructionData{ "ORA_IndirectY", &CPU::ORA, &CPU::INDY, 5, 2 };
+    _opcodeTable[0x09] = InstructionData{ "ORA", "IMM", &CPU::ORA, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x05] = InstructionData{ "ORA", "ZPG", &CPU::ORA, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x15] = InstructionData{ "ORA", "ZPGX", &CPU::ORA, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x0D] = InstructionData{ "ORA", "ABS", &CPU::ORA, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x1D] = InstructionData{ "ORA", "ABSX", &CPU::ORA, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x19] = InstructionData{ "ORA", "ABSY", &CPU::ORA, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0x01] = InstructionData{ "ORA", "INDX", &CPU::ORA, &CPU::INDX, 6, 2 };
+    _opcodeTable[0x11] = InstructionData{ "ORA", "INDY", &CPU::ORA, &CPU::INDY, 5, 2 };
 
     // EOR
-    _opcodeTable[0x49] = InstructionData{ "EOR_Immediate", &CPU::EOR, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x45] = InstructionData{ "EOR_ZeroPage", &CPU::EOR, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x55] = InstructionData{ "EOR_ZeroPageX", &CPU::EOR, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x4D] = InstructionData{ "EOR_Absolute", &CPU::EOR, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x5D] = InstructionData{ "EOR_AbsoluteX", &CPU::EOR, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x59] = InstructionData{ "EOR_AbsoluteY", &CPU::EOR, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0x41] = InstructionData{ "EOR_IndirectX", &CPU::EOR, &CPU::INDX, 6, 2 };
-    _opcodeTable[0x51] = InstructionData{ "EOR_IndirectY", &CPU::EOR, &CPU::INDY, 5, 2 };
+    _opcodeTable[0x49] = InstructionData{ "EOR", "IMM", &CPU::EOR, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x45] = InstructionData{ "EOR", "ZPG", &CPU::EOR, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x55] = InstructionData{ "EOR", "ZPGX", &CPU::EOR, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x4D] = InstructionData{ "EOR", "ABS", &CPU::EOR, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x5D] = InstructionData{ "EOR", "ABSX", &CPU::EOR, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x59] = InstructionData{ "EOR", "ABSY", &CPU::EOR, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0x41] = InstructionData{ "EOR", "INDX", &CPU::EOR, &CPU::INDX, 6, 2 };
+    _opcodeTable[0x51] = InstructionData{ "EOR", "INDY", &CPU::EOR, &CPU::INDY, 5, 2 };
 
     // BIT
-    _opcodeTable[0x24] = InstructionData{ "BIT_ZeroPage", &CPU::BIT, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x2C] = InstructionData{ "BIT_Absolute", &CPU::BIT, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x24] = InstructionData{ "BIT", "ZPG", &CPU::BIT, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x2C] = InstructionData{ "BIT", "ABS", &CPU::BIT, &CPU::ABS, 4, 3 };
 
     // Transfer
-    _opcodeTable[0xAA] = InstructionData{ "TAX_Implied", &CPU::TAX, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x8A] = InstructionData{ "TXA_Implied", &CPU::TXA, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xA8] = InstructionData{ "TAY_Implied", &CPU::TAY, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x98] = InstructionData{ "TYA_Implied", &CPU::TYA, &CPU::IMP, 2, 1 };
-
-    // Illegal - JAM (02, 12, 22, 32, 45, 52, 62, 72, 92, B2, D2, F2)
-    _opcodeTable[0x02] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x12] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x22] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x32] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x42] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x52] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x62] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x72] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x92] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
-    _opcodeTable[0xB2] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
-    _opcodeTable[0xD2] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
-    _opcodeTable[0xF2] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0xAA] = InstructionData{ "TAX", "IMP", &CPU::TAX, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x8A] = InstructionData{ "TXA", "IMP", &CPU::TXA, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xA8] = InstructionData{ "TAY", "IMP", &CPU::TAY, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x98] = InstructionData{ "TYA", "IMP", &CPU::TYA, &CPU::IMP, 2, 1 };
 
     /*
     ################################################################
@@ -241,125 +225,170 @@ CPU::CPU( Bus *bus ) : _bus( bus ), _opcodeTable{}
     ||                                                            ||
     ################################################################
     */
-    // Illegal - NOP (1A, 3A, 5A, 7A, DA, FA, 80, 82, 89, C2, E2, 04, 44, 64, 14, 34, 54, 74, D4,
-    // F4, 0C, 1C, 3C, 5C, 7C, DC, FC)
+
+    // Jams (does nothing)
+    _opcodeTable[0x02] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x12] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x22] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x32] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x42] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x52] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x62] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x72] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x92] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0xB2] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0xD2] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+    _opcodeTable[0xF2] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 3, 1 };
+
     // NOP Implied
-    _opcodeTable[0x1A] = InstructionData{ "*NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x3A] = InstructionData{ "*NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x5A] = InstructionData{ "*NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x7A] = InstructionData{ "*NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xDA] = InstructionData{ "*NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xFA] = InstructionData{ "*NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x1A] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x3A] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x5A] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x7A] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xDA] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xFA] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
+
     // NOP Immediate
-    _opcodeTable[0x80] = InstructionData{ "*NOP_Immediate", &CPU::NOP, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x82] = InstructionData{ "*NOP_Immediate", &CPU::NOP, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x89] = InstructionData{ "*NOP_Immediate", &CPU::NOP, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xC2] = InstructionData{ "*NOP_Immediate", &CPU::NOP, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xE2] = InstructionData{ "*NOP_Immediate", &CPU::NOP, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x80] = InstructionData{ "*NOP", "IMM", &CPU::NOP2, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x82] = InstructionData{ "*NOP", "IMM", &CPU::NOP2, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x89] = InstructionData{ "*NOP", "IMM", &CPU::NOP2, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xC2] = InstructionData{ "*NOP", "IMM", &CPU::NOP2, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xE2] = InstructionData{ "*NOP", "IMM", &CPU::NOP2, &CPU::IMM, 2, 2 };
+
     // NOP Zero Page
-    _opcodeTable[0x04] = InstructionData{ "*NOP_ZeroPage", &CPU::NOP, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x44] = InstructionData{ "*NOP_ZeroPage", &CPU::NOP, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x64] = InstructionData{ "*NOP_ZeroPage", &CPU::NOP, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x04] = InstructionData{ "*NOP", "ZPG", &CPU::NOP2, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x44] = InstructionData{ "*NOP", "ZPG", &CPU::NOP2, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x64] = InstructionData{ "*NOP", "ZPG", &CPU::NOP2, &CPU::ZPG, 3, 2 };
+
     // NOP Zero Page X
-    _opcodeTable[0x14] = InstructionData{ "*NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x34] = InstructionData{ "*NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x54] = InstructionData{ "*NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x74] = InstructionData{ "*NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xD4] = InstructionData{ "*NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xF4] = InstructionData{ "*NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    // NOP Absolute, NOP Absolute X
-    _opcodeTable[0x0C] = InstructionData{ "*NOP_Absolute", &CPU::NOP, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x1C] = InstructionData{ "*NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x3C] = InstructionData{ "*NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x5C] = InstructionData{ "*NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x7C] = InstructionData{ "*NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0xDC] = InstructionData{ "*NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0xFC] = InstructionData{ "*NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x14] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x34] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x54] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x74] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xD4] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xF4] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
+
+    // NOP Absolute
+    _opcodeTable[0x0C] = InstructionData{ "*NOP", "ABS", &CPU::NOP2, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x1C] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x3C] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x5C] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x7C] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xDC] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xFC] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
 
     // SLO
-    _opcodeTable[0x07] = InstructionData{ "*SLO_ZeroPage", &CPU::SLO, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x17] = InstructionData{ "*SLO_ZeroPageX", &CPU::SLO, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x0F] = InstructionData{ "*SLO_Absolute", &CPU::SLO, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x1F] = InstructionData{ "*SLO_AbsoluteX", &CPU::SLO, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0x1B] = InstructionData{ "*SLO_AbsoluteY", &CPU::SLO, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0x03] = InstructionData{ "*SLO_IndirectX", &CPU::SLO, &CPU::INDX, 8, 2 };
-    _opcodeTable[0x13] = InstructionData{ "*SLO_IndirectY", &CPU::SLO, &CPU::INDY, 8, 2, false };
+    _opcodeTable[0x07] = InstructionData{ "*SLO", "ZPG", &CPU::SLO, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x17] = InstructionData{ "*SLO", "ZPGX", &CPU::SLO, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x0F] = InstructionData{ "*SLO", "ABS", &CPU::SLO, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x1F] = InstructionData{ "*SLO", "ABSX", &CPU::SLO, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x1B] = InstructionData{ "*SLO", "ABSY", &CPU::SLO, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0x03] = InstructionData{ "*SLO", "INDX", &CPU::SLO, &CPU::INDX, 8, 2 };
+    _opcodeTable[0x13] = InstructionData{ "*SLO", "INDY", &CPU::SLO, &CPU::INDY, 8, 2, false, true };
 
-    // RLA: 27, 37, 2F, 3F, 3B, 23, 33
-    _opcodeTable[0x27] = InstructionData{ "*RLA_ZeroPage", &CPU::RLA, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x37] = InstructionData{ "*RLA_ZeroPageX", &CPU::RLA, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x2F] = InstructionData{ "*RLA_Absolute", &CPU::RLA, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x3F] = InstructionData{ "*RLA_AbsoluteX", &CPU::RLA, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0x3B] = InstructionData{ "*RLA_AbsoluteY", &CPU::RLA, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0x23] = InstructionData{ "*RLA_IndirectX", &CPU::RLA, &CPU::INDX, 8, 2 };
-    _opcodeTable[0x33] = InstructionData{ "*RLA_IndirectY", &CPU::RLA, &CPU::INDY, 8, 2, false };
+    // RLA
+    _opcodeTable[0x27] = InstructionData{ "*RLA", "ZPG", &CPU::RLA, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x37] = InstructionData{ "*RLA", "ZPGX", &CPU::RLA, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x2F] = InstructionData{ "*RLA", "ABS", &CPU::RLA, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x3F] = InstructionData{ "*RLA", "ABSX", &CPU::RLA, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x3B] = InstructionData{ "*RLA", "ABSY", &CPU::RLA, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0x23] = InstructionData{ "*RLA", "INDX", &CPU::RLA, &CPU::INDX, 8, 2 };
+    _opcodeTable[0x33] = InstructionData{ "*RLA", "INDY", &CPU::RLA, &CPU::INDY, 8, 2, false, true };
 
-    // SRE: 47, 57, 4F, 5F, 5B, 43, 53
-    _opcodeTable[0x47] = InstructionData{ "*SRE_ZeroPage", &CPU::SRE, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x57] = InstructionData{ "*SRE_ZeroPageX", &CPU::SRE, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x4F] = InstructionData{ "*SRE_Absolute", &CPU::SRE, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x5F] = InstructionData{ "*SRE_AbsoluteX", &CPU::SRE, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0x5B] = InstructionData{ "*SRE_AbsoluteY", &CPU::SRE, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0x43] = InstructionData{ "*SRE_IndirectX", &CPU::SRE, &CPU::INDX, 8, 2 };
-    _opcodeTable[0x53] = InstructionData{ "*SRE_IndirectY", &CPU::SRE, &CPU::INDY, 8, 2, false };
+    // SRE
+    _opcodeTable[0x47] = InstructionData{ "*SRE", "ZPG", &CPU::SRE, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x57] = InstructionData{ "*SRE", "ZPGX", &CPU::SRE, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x4F] = InstructionData{ "*SRE", "ABS", &CPU::SRE, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x5F] = InstructionData{ "*SRE", "ABSX", &CPU::SRE, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x5B] = InstructionData{ "*SRE", "ABSY", &CPU::SRE, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0x43] = InstructionData{ "*SRE", "INDX", &CPU::SRE, &CPU::INDX, 8, 2 };
+    _opcodeTable[0x53] = InstructionData{ "*SRE", "INDY", &CPU::SRE, &CPU::INDY, 8, 2, false, true };
 
-    // RRA: 67, 77, 6F, 7F, 7B, 63, 73
-    _opcodeTable[0x67] = InstructionData{ "*RRA_ZeroPage", &CPU::RRA, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x77] = InstructionData{ "*RRA_ZeroPageX", &CPU::RRA, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x6F] = InstructionData{ "*RRA_Absolute", &CPU::RRA, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x7F] = InstructionData{ "*RRA_AbsoluteX", &CPU::RRA, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0x7B] = InstructionData{ "*RRA_AbsoluteY", &CPU::RRA, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0x63] = InstructionData{ "*RRA_IndirectX", &CPU::RRA, &CPU::INDX, 8, 2 };
-    _opcodeTable[0x73] = InstructionData{ "*RRA_IndirectY", &CPU::RRA, &CPU::INDY, 8, 2, false };
+    // RRA
+    _opcodeTable[0x67] = InstructionData{ "*RRA", "ZPG", &CPU::RRA, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x77] = InstructionData{ "*RRA", "ZPGX", &CPU::RRA, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x6F] = InstructionData{ "*RRA", "ABS", &CPU::RRA, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x7F] = InstructionData{ "*RRA", "ABSX", &CPU::RRA, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x7B] = InstructionData{ "*RRA", "ABSY", &CPU::RRA, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0x63] = InstructionData{ "*RRA", "INDX", &CPU::RRA, &CPU::INDX, 8, 2 };
+    _opcodeTable[0x73] = InstructionData{ "*RRA", "INDY", &CPU::RRA, &CPU::INDY, 8, 2, false, true };
 
-    // SAX: 87, 97, 8F, 83
-    _opcodeTable[0x87] = InstructionData{ "*SAX_ZeroPage", &CPU::SAX, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x97] = InstructionData{ "*SAX_ZeroPageY", &CPU::SAX, &CPU::ZPGY, 4, 2 };
-    _opcodeTable[0x8F] = InstructionData{ "*SAX_Absolute", &CPU::SAX, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x83] = InstructionData{ "*SAX_IndirectX", &CPU::SAX, &CPU::INDX, 6, 2 };
+    // SAX
+    _opcodeTable[0x87] = InstructionData{ "*SAX", "ZPG", &CPU::SAX, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x97] = InstructionData{ "*SAX", "ZPGY", &CPU::SAX, &CPU::ZPGY, 4, 2, true, true };
+    _opcodeTable[0x8F] = InstructionData{ "*SAX", "ABS", &CPU::SAX, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x83] = InstructionData{ "*SAX", "INDX", &CPU::SAX, &CPU::INDX, 6, 2 };
 
-    // LAX: A7, B7, AF, BF, A3, B3
-    _opcodeTable[0xA7] = InstructionData{ "*LAX_ZeroPage", &CPU::LAX, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xB7] = InstructionData{ "*LAX_ZeroPageY", &CPU::LAX, &CPU::ZPGY, 4, 2 };
-    _opcodeTable[0xAF] = InstructionData{ "*LAX_Absolute", &CPU::LAX, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xBF] = InstructionData{ "*LAX_AbsoluteY", &CPU::LAX, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0xA3] = InstructionData{ "*LAX_IndirectX", &CPU::LAX, &CPU::INDX, 6, 2 };
-    _opcodeTable[0xB3] = InstructionData{ "*LAX_IndirectY", &CPU::LAX, &CPU::INDY, 5, 2 };
+    // LAX
+    _opcodeTable[0xA7] = InstructionData{ "*LAX", "ZPG", &CPU::LAX, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xB7] = InstructionData{ "*LAX", "ZPGY", &CPU::LAX, &CPU::ZPGY, 4, 2, true, true };
+    _opcodeTable[0xAF] = InstructionData{ "*LAX", "ABS", &CPU::LAX, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xBF] = InstructionData{ "*LAX", "ABSY", &CPU::LAX, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0xA3] = InstructionData{ "*LAX", "INDX", &CPU::LAX, &CPU::INDX, 6, 2 };
+    _opcodeTable[0xB3] = InstructionData{ "*LAX", "INDY", &CPU::LAX, &CPU::INDY, 5, 2 };
 
-    // DCP: C7, D7, CF, DF, DB, C3, D3
-    _opcodeTable[0xC7] = InstructionData{ "*DCP_ZeroPage", &CPU::DCP, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0xD7] = InstructionData{ "*DCP_ZeroPageX", &CPU::DCP, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0xCF] = InstructionData{ "*DCP_Absolute", &CPU::DCP, &CPU::ABS, 6, 3 };
-    _opcodeTable[0xDF] = InstructionData{ "*DCP_AbsoluteX", &CPU::DCP, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0xDB] = InstructionData{ "*DCP_AbsoluteY", &CPU::DCP, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0xC3] = InstructionData{ "*DCP_IndirectX", &CPU::DCP, &CPU::INDX, 8, 2 };
-    _opcodeTable[0xD3] = InstructionData{ "*DCP_IndirectY", &CPU::DCP, &CPU::INDY, 8, 2, false };
+    // DCP
+    _opcodeTable[0xC7] = InstructionData{ "*DCP", "ZPG", &CPU::DCP, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0xD7] = InstructionData{ "*DCP", "ZPGX", &CPU::DCP, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0xCF] = InstructionData{ "*DCP", "ABS", &CPU::DCP, &CPU::ABS, 6, 3 };
+    _opcodeTable[0xDF] = InstructionData{ "*DCP", "ABSX", &CPU::DCP, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0xDB] = InstructionData{ "*DCP", "ABSY", &CPU::DCP, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0xC3] = InstructionData{ "*DCP", "INDX", &CPU::DCP, &CPU::INDX, 8, 2 };
+    _opcodeTable[0xD3] = InstructionData{ "*DCP", "INDY", &CPU::DCP, &CPU::INDY, 8, 2, false, true };
 
-    // ISC: E7, F7, EF, FF, FB, E3, F3
-    _opcodeTable[0xE7] = InstructionData{ "*ISC_ZeroPage", &CPU::ISC, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0xF7] = InstructionData{ "*ISC_ZeroPageX", &CPU::ISC, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0xEF] = InstructionData{ "*ISC_Absolute", &CPU::ISC, &CPU::ABS, 6, 3 };
-    _opcodeTable[0xFF] = InstructionData{ "*ISC_AbsoluteX", &CPU::ISC, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0xFB] = InstructionData{ "*ISC_AbsoluteY", &CPU::ISC, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0xE3] = InstructionData{ "*ISC_IndirectX", &CPU::ISC, &CPU::INDX, 8, 2 };
-    _opcodeTable[0xF3] = InstructionData{ "*ISC_IndirectY", &CPU::ISC, &CPU::INDY, 8, 2, false };
+    // ISC
+    _opcodeTable[0xE7] = InstructionData{ "*ISC", "ZPG", &CPU::ISC, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0xF7] = InstructionData{ "*ISC", "ZPGX", &CPU::ISC, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0xEF] = InstructionData{ "*ISC", "ABS", &CPU::ISC, &CPU::ABS, 6, 3 };
+    _opcodeTable[0xFF] = InstructionData{ "*ISC", "ABSX", &CPU::ISC, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0xFB] = InstructionData{ "*ISC", "ABSY", &CPU::ISC, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0xE3] = InstructionData{ "*ISC", "INDX", &CPU::ISC, &CPU::INDX, 8, 2 };
+    _opcodeTable[0xF3] = InstructionData{ "*ISC", "INDY", &CPU::ISC, &CPU::INDY, 8, 2, false, true };
 
-    // USBC: EB, this is just the normal SBC in immediate mode
-    _opcodeTable[0xEB] = InstructionData{ "*SBC_Immediate", &CPU::SBC, &CPU::IMM, 2, 2 };
+    // USBC
+    _opcodeTable[0xEB] = InstructionData{ "*SBC", "IMM", &CPU::SBC, &CPU::IMM, 2, 2 };
 
-    // ALR: 4B, ARR: 6B, ANE: 8B
-    _opcodeTable[0x4B] = InstructionData{ "*ALR_Immediate", &CPU::ALR, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x6B] = InstructionData{ "*ARR_Immediate", &CPU::ARR, &CPU::IMM, 2, 2 };
+    // ALR, ARR, ANE
+    _opcodeTable[0x4B] = InstructionData{ "*ALR", "IMM", &CPU::ALR, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x6B] = InstructionData{ "*ARR", "IMM", &CPU::ARR, &CPU::IMM, 2, 2 };
 
-    // ANC: 0B, 2B
-    _opcodeTable[0x0B] = InstructionData{ "*ANC_Immediate", &CPU::ANC, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x2B] = InstructionData{ "*ANC_Immediate", &CPU::ANC, &CPU::IMM, 2, 2 };
+    // ANC
+    _opcodeTable[0x0B] = InstructionData{ "*ANC", "IMM", &CPU::ANC, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x2B] = InstructionData{ "*ANC", "IMM", &CPU::ANC, &CPU::IMM, 2, 2 };
 
-    // LXA: AB
-    _opcodeTable[0xAB] = InstructionData{ "*LXA_Immediate", &CPU::LXA, &CPU::IMM, 2, 2 };
+    // LXA
+    _opcodeTable[0xAB] = InstructionData{ "*LXA", "IMM", &CPU::LXA, &CPU::IMM, 2, 2 };
 
-    // SBX: CB
-    _opcodeTable[0xCB] = InstructionData{ "*SBX_Immediate", &CPU::SBX, &CPU::IMM, 2, 2 };
+    // SBX
+    _opcodeTable[0xCB] = InstructionData{ "*SBX", "IMM", &CPU::SBX, &CPU::IMM, 2, 2 };
+
+    // Validate Opcode names and address mode strings
+    for ( int i = 0; i < 256; i++ )
+    {
+        string const name = _opcodeTable[i].name;
+        // if no name, skip, it's an empty entry
+        if ( name.empty() )
+        {
+            continue;
+        }
+        string const addr_mode = _opcodeTable[i].addr_mode;
+        if ( !utils::isValidOpcodeName( name ) )
+        {
+            string output = "Invalid opcode name: " + name;
+            output += " for opcode: " + utils::toHex( i, 2 );
+            output += '\n';
+            output += "Valid names: \n" + utils::getAvailableOpcodeNames();
+            throw std::runtime_error( output );
+        }
+        if ( !utils::isValidAddrModeStr( addr_mode ) )
+        {
+            string output = "Invalid address mode string: " + addr_mode;
+            output += " for opcode: " + utils::toHex( i, 2 );
+            output += '\n';
+            output += "Valid address mode strings: \n" + utils::getAvailableAddrModes();
+            throw std::runtime_error( output );
+        };
+    }
 };
 
 // Getters
@@ -392,22 +421,49 @@ void CPU::SetCycles( u64 value ) { _cycles = value; }
 auto CPU::Read( u16 address ) const -> u8 { return _bus->Read( address ); }
 void CPU::Write( u16 address, u8 data ) const { _bus->Write( address, data ); }
 
+// Read with cycle spend
+auto CPU::ReadAndTick( u16 address ) -> u8
+{
+    u8 const data = Read( address );
+    Tick();
+    return data;
+}
+
+// Write and spend a cycle
+auto CPU::WriteAndTick( u16 address, u8 data ) -> void
+{
+    Write( address, data );
+    Tick();
+}
+
 u8 CPU::Fetch()
 {
     // Read the current PC location and increment it
-    return Read( _pc++ );
+    // return Read( _pc++ );
+
+    u8 const opcode = ReadAndTick( _pc++ );
+    _opcode = opcode;
+    return opcode;
+}
+
+void CPU::Tick()
+{
+    // Increment the cycle count
+    _cycles++;
+    _bus->TickPPU();
+    _bus->TickPPU();
+    _bus->TickPPU();
 }
 
 /**
- * @brief Executes a single CPU cycle.
+ * @brief Decode and execute an instruction
  *
  * This function fetches the next opcode from memory, decodes it using the opcode table,
- * and executes that instruction. It also adds the number of cycles the instruction
- * takes to the total cycle count.
+ * and executes that instruction.
  *
  * If the opcode is invalid, an error message is printed to stderr.
  */
-void CPU::Tick()
+void CPU::DecodeExecute()
 {
 
     // Fetch the next opcode and increment the program counter
@@ -424,18 +480,24 @@ void CPU::Tick()
         // Used in addressing modes: ABSX, ABSY, INDY
         _currentPageCrossPenalty = instruction.pageCrossPenalty;
 
+        // Write / modify instructions use a dummy read before writing, so
+        // we should set a flag for those
+        _is_write_modify = instruction.isWriteModify;
+
+        // Set current instr mnemonic globally
+        _instruction_name = instruction.name;
+
+        // Set current address mode string globally
+        _addr_mode = instruction.addr_mode;
+
         // Calculate the address using the addressing mode
         u16 const address = ( this->*addressing_mode_handler )();
-
-        // Add the number of cycles the instruction takes
-        _cycles += instruction.cycles;
-        _bus->SyncPPU( _cycles );
 
         // Execute the instruction fetched from the opcode table
         ( this->*instruction_handler )( address );
 
-        // Reset the _imp flag. It's triggered in IMP addressing mode
-        _imp = false;
+        // Reset flags
+        _is_write_modify = false;
     }
     else
     {
@@ -453,21 +515,8 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
      */
     std::string output;
 
-    // Fetch the instruction name and address mode from the opcode table
-    std::string const &name_addrmode = _opcodeTable[Read( _pc )].name;
-    if ( name_addrmode.empty() )
-    {
-        std::cerr << "Attempted to grab from a non existing table entry at PC: "
-                  << utils::toHex( _pc, 4 ) << '\n';
-        std::cerr << "Opcode: " << utils::toHex( Read( _pc ), 2 ) << '\n';
-        // This is only used for debugging, so we can throw an exception
-        throw std::runtime_error( "Invalid opcode" );
-    }
-
-    // Split name and addressing mode
-    size_t const      split_pos = name_addrmode.find( '_' );
-    std::string       name = name_addrmode.substr( 0, split_pos );
-    std::string const addr_mode = name_addrmode.substr( split_pos + 1 );
+    std::string       name = _instruction_name;
+    std::string const addr_mode = _addr_mode;
 
     // Program counter address
     // i.e. FFFF
@@ -496,49 +545,49 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
     u8          value = 0x00;
     u8          low = 0x00;
     u8          high = 0x00;
-    if ( addr_mode == "Implied" )
+    if ( addr_mode == "IMP" )
     {
         // Nothing to prefix
     }
-    else if ( addr_mode == "Immediate" )
+    else if ( addr_mode == "IMM" )
     {
         value = Read( _pc + 1 );
         assembly_str += "#$" + utils::toHex( value, 2 );
     }
-    else if ( addr_mode == "ZeroPage" || addr_mode == "ZeroPageX" || addr_mode == "ZeroPageY" )
+    else if ( addr_mode == "ZPG" || addr_mode == "ZPGX" || addr_mode == "ZPGY" )
     {
         value = Read( _pc + 1 );
         assembly_str += "$" + utils::toHex( value, 2 );
 
-        ( addr_mode == "ZeroPageX" )   ? assembly_str += ", X"
-        : ( addr_mode == "ZeroPageY" ) ? assembly_str += ", Y"
-                                       : assembly_str += "";
+        ( addr_mode == "ZPGX" )   ? assembly_str += ", X"
+        : ( addr_mode == "ZPGY" ) ? assembly_str += ", Y"
+                                  : assembly_str += "";
     }
-    else if ( addr_mode == "Absolute" || addr_mode == "AbsoluteX" || addr_mode == "AbsoluteY" )
+    else if ( addr_mode == "ABS" || addr_mode == "ABSX" || addr_mode == "ABSY" )
     {
         low = Read( _pc + 1 );
         high = Read( _pc + 2 );
         u16 const address = ( high << 8 ) | low;
 
         assembly_str += "$" + utils::toHex( address, 4 );
-        ( addr_mode == "AbsoluteX" )   ? assembly_str += ", X"
-        : ( addr_mode == "AbsoluteY" ) ? assembly_str += ", Y"
-                                       : assembly_str += "";
+        ( addr_mode == "ABSX" )   ? assembly_str += ", X"
+        : ( addr_mode == "ABSY" ) ? assembly_str += ", Y"
+                                  : assembly_str += "";
     }
-    else if ( addr_mode == "Indirect" )
+    else if ( addr_mode == "IND" )
     {
         low = Read( _pc + 1 );
         high = Read( _pc + 2 );
         u16 const address = ( high << 8 ) | low;
         assembly_str += "($" + utils::toHex( address, 4 ) + ")";
     }
-    else if ( addr_mode == "IndirectX" || addr_mode == "IndirectY" )
+    else if ( addr_mode == "INDX" || addr_mode == "INDY" )
     {
         value = Read( _pc + 1 );
-        ( addr_mode == "IndirectX" ) ? assembly_str += "($" + utils::toHex( value, 2 ) + ", X)"
-                                     : assembly_str += "($" + utils::toHex( value, 2 ) + "), Y";
+        ( addr_mode == "INDX" ) ? assembly_str += "($" + utils::toHex( value, 2 ) + ", X)"
+                                : assembly_str += "($" + utils::toHex( value, 2 ) + "), Y";
     }
-    else if ( addr_mode == "Relative" )
+    else if ( addr_mode == "REL" )
     {
         value = Read( _pc + 1 );
         s8 const  offset = static_cast<s8>( value );
@@ -577,8 +626,7 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
         std::string status_flags_str;
         for ( int i = 7; i >= 0; i-- )
         {
-            status_flags_str +=
-                ( _p & ( 1 << i ) ) != 0 ? status_flags[7 - i] : status_flags_lower[7 - i];
+            status_flags_str += ( _p & ( 1 << i ) ) != 0 ? status_flags[7 - i] : status_flags_lower[7 - i];
         }
         status_str += status_flags_str;
 
@@ -589,10 +637,10 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
         u16 const   ppu_cycles = _bus->GetPpuCycles();
         std::string ppu_cycles_str = std::to_string( ppu_cycles + 2 );
         ppu_cycles_str += std::string( 4 - ppu_cycles_str.size(), ' ' );
-        output += "  PPU: " + ppu_cycles_str;
+        output += "  PPU cycle: " + ppu_cycles_str;
 
         // cycle count
-        output += "  cycle: " + std::to_string( _cycles + 1 );
+        output += "  CPU cycle: " + std::to_string( _cycles + 1 );
     }
 
     return output;
@@ -614,8 +662,10 @@ void CPU::Reset()
     if ( !_bus->IsTestMode() )
     {
 
-        _cycles += 7;
-        _bus->SyncPPU( _cycles );
+        for ( u8 i = 0; i < 7; i++ )
+        {
+            Tick();
+        }
     }
     else
     {
@@ -637,7 +687,7 @@ auto CPU::IMP() -> u16
      * @brief Implicit addressing mode
      * This mode does not require an operand
      */
-    _imp = true;
+    Tick();
     return 0;
 }
 
@@ -658,7 +708,7 @@ auto CPU::ZPG() -> u16
      * Returns the address from the zero page (0x0000 - 0x00FF).
      * The value of the next byte is the address in the zero page.
      */
-    return Read( _pc++ ) & 0x00FF;
+    return ReadAndTick( _pc++ ) & 0x00FF;
 }
 
 auto CPU::ZPGX() -> u16
@@ -668,7 +718,10 @@ auto CPU::ZPGX() -> u16
      * Returns the address from the zero page (0x0000 - 0x00FF) + X register
      * The value of the next byte is the address in the zero page.
      */
-    return ( Read( _pc++ ) + _x ) & 0x00FF;
+    u8 const  zero_page_address = ReadAndTick( _pc++ );
+    u16 const final_address = ( zero_page_address + _x ) & 0x00FF;
+    Tick(); // Account for calculating the final address
+    return final_address;
 }
 
 auto CPU::ZPGY() -> u16
@@ -678,7 +731,13 @@ auto CPU::ZPGY() -> u16
      * Returns the address from the zero page (0x0000 - 0x00FF) + Y register
      * The value of the next byte is the address in the zero page.
      */
-    return ( Read( _pc++ ) + _y ) & 0x00FF;
+    u8 const zero_page_address = ( ReadAndTick( _pc++ ) + _y ) & 0x00FF;
+
+    if ( _is_write_modify )
+    {
+        Tick();
+    }
+    return zero_page_address;
 }
 
 auto CPU::ABS() -> u16
@@ -687,8 +746,8 @@ auto CPU::ABS() -> u16
      * @brief Absolute addressing mode
      * Constructs a 16-bit address from the next two bytes
      */
-    u16 const low = Read( _pc++ );
-    u16 const high = Read( _pc++ );
+    u16 const low = ReadAndTick( _pc++ );
+    u16 const high = ReadAndTick( _pc++ );
     return ( high << 8 ) | low;
 }
 
@@ -699,8 +758,8 @@ auto CPU::ABSX() -> u16
      * Constructs a 16-bit address from the next two bytes and adds the X register to the final
      * address
      */
-    u16 const low = Read( _pc++ );
-    u16 const high = Read( _pc++ );
+    u16 const low = ReadAndTick( _pc++ );
+    u16 const high = ReadAndTick( _pc++ );
     u16 const address = ( high << 8 ) | low;
     u16 const final_address = address + _x;
 
@@ -708,10 +767,14 @@ auto CPU::ABSX() -> u16
     // Instructions that should ignore this: ASL, ROL, LSR, ROR, STA, DEC, INC
     if ( _currentPageCrossPenalty && ( final_address & 0xFF00 ) != ( address & 0xFF00 ) )
     {
-        _cycles++;
-        _bus->SyncPPU( _cycles );
+        Tick();
     }
 
+    if ( _is_write_modify )
+    {
+        // Dummy read, in preparation to overwrite the address
+        Tick();
+    }
     return final_address;
 }
 
@@ -722,8 +785,8 @@ auto CPU::ABSY() -> u16
      * Constructs a 16-bit address from the next two bytes and adds the Y register to the final
      * address
      */
-    u16 const low = Read( _pc++ );
-    u16 const high = Read( _pc++ );
+    u16 const low = ReadAndTick( _pc++ );
+    u16 const high = ReadAndTick( _pc++ );
     u16 const address = ( high << 8 ) | low;
     u16 const final_address = address + _y;
 
@@ -731,8 +794,12 @@ auto CPU::ABSY() -> u16
     // Instructions that should ignore this: STA
     if ( _currentPageCrossPenalty && ( final_address & 0xFF00 ) != ( address & 0xFF00 ) )
     {
-        _cycles++;
-        _bus->SyncPPU( _cycles );
+        Tick();
+    }
+    if ( _is_write_modify )
+    {
+        // Dummy read, in preparation to overwrite the address
+        Tick();
     }
 
     return final_address;
@@ -748,11 +815,11 @@ auto CPU::IND() -> u16
      * There's a hardware bug that prevents the address from crossing a page boundary
      */
 
-    u16 const ptr_low = Read( _pc++ );
-    u16 const ptr_high = Read( _pc++ );
+    u16 const ptr_low = ReadAndTick( _pc++ );
+    u16 const ptr_high = ReadAndTick( _pc++ );
     u16 const ptr = ( ptr_high << 8 ) | ptr_low;
 
-    u8 const address_low = Read( ptr );
+    u8 const address_low = ReadAndTick( ptr );
     u8       address_high; // NOLINT
 
     // 6502 Bug: If the pointer address wraps around a page boundary (e.g. 0x01FF),
@@ -760,11 +827,11 @@ auto CPU::IND() -> u16
     // the same page (0x0100) instead of the start of the next page (0x0200).
     if ( ptr_low == 0xFF )
     {
-        address_high = Read( ptr & 0xFF00 );
+        address_high = ReadAndTick( ptr & 0xFF00 );
     }
     else
     {
-        address_high = Read( ptr + 1 );
+        address_high = ReadAndTick( ptr + 1 );
     }
 
     return ( address_high << 8 ) | address_low;
@@ -778,9 +845,10 @@ auto CPU::INDX() -> u16
      * X register is added to the zero-page address to get the pointer address
      * Final address is the value stored at the POINTER address
      */
-    u8 const  zero_page_address = ( Read( _pc++ ) + _x ) & 0x00FF;
-    u16 const ptr_low = Read( zero_page_address );
-    u16 const ptr_high = Read( ( zero_page_address + 1 ) & 0x00FF );
+    Tick();                                                                 // Account for operand fetch
+    u8 const  zero_page_address = ( ReadAndTick( _pc++ ) + _x ) & 0x00FF;   // 1 cycle
+    u16 const ptr_low = ReadAndTick( zero_page_address );                   // 1 cycle
+    u16 const ptr_high = ReadAndTick( ( zero_page_address + 1 ) & 0x00FF ); // 1 cycle
     return ( ptr_high << 8 ) | ptr_low;
 }
 
@@ -792,9 +860,9 @@ auto CPU::INDY() -> u16
      * The value stored at the zero-page address is the pointer address
      * The value in the Y register is added to the FINAL address
      */
-    u16 const zero_page_address = Read( _pc++ );
-    u16 const ptr_low = Read( zero_page_address );
-    u16 const ptr_high = Read( ( zero_page_address + 1 ) & 0x00FF );
+    u16 const zero_page_address = ReadAndTick( _pc++ );
+    u16 const ptr_low = ReadAndTick( zero_page_address );
+    u16 const ptr_high = ReadAndTick( ( zero_page_address + 1 ) & 0x00FF );
 
     u16 const address = ( ( ptr_high << 8 ) | ptr_low ) + _y;
 
@@ -802,8 +870,13 @@ auto CPU::INDY() -> u16
     // Instructions that should ignore this: STA
     if ( _currentPageCrossPenalty && ( address & 0xFF00 ) != ( ptr_high << 8 ) )
     {
-        _cycles++;
-        _bus->SyncPPU( _cycles );
+        Tick();
+    }
+
+    if ( _is_write_modify )
+    {
+        // Dummy read, in preparation to overwrite the address
+        Tick();
     }
     return address;
 }
@@ -815,7 +888,7 @@ auto CPU::REL() -> u16
      * The next byte is a signed offset
      * Sets the program counter between -128 and +127 bytes from the current location
      */
-    s8 const  offset = static_cast<s8>( Read( _pc++ ) );
+    s8 const  offset = static_cast<s8>( ReadAndTick( _pc++ ) );
     u16 const address = _pc + offset;
     return address;
 }
@@ -834,20 +907,20 @@ void CPU::LoadRegister( u16 address, u8 &reg )
      * @brief It loads a register with a value from memory
      * Used by LDA, LDX, and LDY instructions
      */
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
     reg = value;
 
     // Set zero and negative flags
     SetZeroAndNegativeFlags( value );
 };
 
-void CPU::StoreRegister( u16 address, u8 reg ) const
+void CPU::StoreRegister( u16 address, u8 reg )
 {
     /*
      * @brief It stores a register value in memory
      * Used by STA, STX, and STY instructions
      */
-    Write( address, reg );
+    WriteAndTick( address, reg );
 };
 
 void CPU::SetFlags( const u8 flag )
@@ -948,8 +1021,6 @@ void CPU::BranchOnStatus( u16 offsetAddress, u8 flag, bool isSet )
         {
             _cycles += 1;
         }
-
-        _bus->SyncPPU( _cycles );
     }
     // Path will not branch, nothing to do
 }
@@ -961,15 +1032,22 @@ void CPU::CompareAddressWithRegister( u16 address, u8 reg )
      * Used by CMP, CPX, and CPY instructions
      */
 
-    u8 const value = Read( address );
+    u8 value = 0;
+    if ( _instruction_name == "*DCP" )
+    {
+        value = Read( address ); // 0 cycles
+    }
+    else
+    {
+        value = ReadAndTick( address );
+    }
 
     // Set the zero flag if the values are equal
     ( reg == value ) ? SetFlags( Status::Zero ) : ClearFlags( Status::Zero );
 
     // Set negative flag if the result is negative,
     // i.e. the sign bit is set
-    ( ( reg - value ) & 0b10000000 ) != 0 ? SetFlags( Status::Negative )
-                                          : ClearFlags( Status::Negative );
+    ( ( reg - value ) & 0b10000000 ) != 0 ? SetFlags( Status::Negative ) : ClearFlags( Status::Negative );
 
     // Set the carry flag if the reg >= value
     ( reg >= value ) ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
@@ -982,7 +1060,7 @@ void CPU::StackPush( u8 value )
      * The stack pointer is decremented and the value is written to the stack
      * Stack addresses are between 0x0100 and 0x01FF
      */
-    Write( 0x0100 + _s--, value );
+    WriteAndTick( 0x0100 + _s--, value );
 }
 
 u8 CPU::StackPop()
@@ -992,7 +1070,7 @@ u8 CPU::StackPop()
      * The stack pointer is incremented and the value is read from the stack
      * Stack addresses are between 0x0100 and 0x01FF
      */
-    return Read( 0x0100 + ++_s );
+    return ReadAndTick( 0x0100 + ++_s );
 }
 
 /*
@@ -1022,6 +1100,17 @@ void CPU::NOP( u16 address ) // NOLINT
      * NOP Implied: 7A(2)
      * NOP Implied: DA(2)
      * NOP Implied: FA(2)
+     */
+    (void) address;
+}
+
+void CPU::NOP2( u16 address ) // NOLINT
+{
+    /*
+     * @brief No operation, has an additional cycle
+     * N Z C I D V
+     * - - - - - -
+     * --  Illegal  --
      * NOP Immediate: 80(2)
      * NOP Immediate: 82(2)
      * NOP Immediate: 89(2)
@@ -1044,6 +1133,7 @@ void CPU::NOP( u16 address ) // NOLINT
      * NOP Absolute: DC(4)
      * NOP Absolute: FC(4)
      */
+    Tick();
     (void) address;
 }
 
@@ -1161,7 +1251,16 @@ void CPU::ADC( u16 address )
      * ADC Indirect X: 61(6)
      * ADC Indirect Y: 71(5+)
      */
-    u8 const value = Read( address );
+    u8 value = 0;
+
+    if ( _instruction_name == "*RRA" )
+    {
+        value = Read( address ); // No cycle spend
+    }
+    else
+    {
+        value = ReadAndTick( address );
+    }
 
     // Store the sum in a 16-bit variable to check for overflow
     u8 const  carry = IsFlagSet( Status::Carry ) ? 1 : 0;
@@ -1214,7 +1313,16 @@ void CPU::SBC( u16 address )
      * SBC Immediate: EB(2)
      */
 
-    u8 const value = Read( address );
+    u8 value = 0;
+    if ( _instruction_name == "*ISC" )
+    {
+        value = Read( address ); // 0 cycles
+    }
+    else
+    {
+        value = ReadAndTick( address );
+    }
+    // u8 const value = ReadAndTick( address );
 
     // Store diff in a 16-bit variable to check for overflow
     u8 const  carry = IsFlagSet( Status::Carry ) ? 0 : 1;
@@ -1258,10 +1366,11 @@ void CPU::INC( u16 address )
      * INC Absolute: EE(6)
      * INC Absolute X: FE(7)
      */
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
+    Tick(); // Dummy write
     u8 const result = value + 1;
     SetZeroAndNegativeFlags( result );
-    Write( address, result );
+    WriteAndTick( address, result );
 }
 
 void CPU::INX( u16 address )
@@ -1304,10 +1413,11 @@ void CPU::DEC( u16 address )
      * DEC Absolute: CE(6)
      * DEC Absolute X: DE(7)
      */
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
+    Tick(); // Dummy write
     u8 const result = value - 1;
     SetZeroAndNegativeFlags( result );
-    Write( address, result );
+    WriteAndTick( address, result );
 }
 
 void CPU::DEX( u16 address )
@@ -1566,7 +1676,7 @@ void CPU::PHA( const u16 address )
     const u8 stack_pointer = GetStackPointer();
 
     // Push the accumulator onto the stack
-    Write( 0x0100 + stack_pointer, GetAccumulator() );
+    WriteAndTick( 0x0100 + stack_pointer, GetAccumulator() );
 
     // Decrement the stack pointer
     SetStackPointer( stack_pointer - 1 );
@@ -1590,7 +1700,7 @@ void CPU::PHP( const u16 address )
     status |= Break;
 
     // Push the modified status register onto the stack
-    Write( 0x0100 + stack_pointer, status );
+    WriteAndTick( 0x0100 + stack_pointer, status );
 
     SetStackPointer( stack_pointer - 1 );
 }
@@ -1609,7 +1719,8 @@ void CPU::PLA( const u16 address )
     SetStackPointer( GetStackPointer() + 1 );
 
     // Get the accumulator from the stack and set the zero and negative flags
-    SetAccumulator( Read( 0x100 + GetStackPointer() ) );
+    SetAccumulator( ReadAndTick( 0x100 + GetStackPointer() ) );
+    Tick(); // Dummy read
     SetZeroAndNegativeFlags( _a );
 }
 
@@ -1626,8 +1737,9 @@ void CPU::PLP( const u16 address )
     // Increment the stack pointer first
     SetStackPointer( GetStackPointer() + 1 );
 
-    SetStatusRegister( Read( 0x100 + GetStackPointer() ) );
+    SetStatusRegister( ReadAndTick( 0x100 + GetStackPointer() ) );
     ClearFlags( Status::Break );
+    Tick(); // Dummy read
     SetFlags( Status::Unused );
 }
 
@@ -1669,7 +1781,7 @@ void CPU::ASL( u16 address )
      *   ASL Absolute X: 1E(7)
      */
 
-    if ( _imp )
+    if ( _addr_mode == "IMP" )
     {
         u8 accumulator = GetAccumulator();
         // Set the carry flag if bit 7 is set
@@ -1686,7 +1798,9 @@ void CPU::ASL( u16 address )
     }
     else
     {
-        u8 const value = Read( address );
+        u8 const value = ReadAndTick( address );
+
+        Tick(); // simulate dummy write
 
         // Set the carry flag if bit 7 is set
         ( value & 0b10000000 ) != 0 ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
@@ -1697,7 +1811,7 @@ void CPU::ASL( u16 address )
         SetZeroAndNegativeFlags( result );
 
         // Write the result back to memory
-        Write( address, result );
+        WriteAndTick( address, result );
     }
 }
 
@@ -1714,7 +1828,7 @@ void CPU::LSR( u16 address )
      *   LSR Absolute X: 5E(7)
      */
 
-    if ( _imp )
+    if ( _addr_mode == "IMP" )
     {
         u8 accumulator = GetAccumulator();
         // Set the carry flag if bit 0 is set
@@ -1731,7 +1845,8 @@ void CPU::LSR( u16 address )
     }
     else
     {
-        u8 const value = Read( address );
+        u8 const value = ReadAndTick( address );
+        Tick(); // simulate dummy write
 
         // Set the carry flag if bit 0 is set
         ( value & 0b00000001 ) != 0 ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
@@ -1742,7 +1857,7 @@ void CPU::LSR( u16 address )
         SetZeroAndNegativeFlags( result );
 
         // Write the result back to memory
-        Write( address, result );
+        WriteAndTick( address, result );
     }
 }
 
@@ -1760,7 +1875,7 @@ void CPU::ROL( u16 address )
      */
 
     const u8 carry = IsFlagSet( Status::Carry ) ? 1 : 0;
-    if ( _imp )
+    if ( _addr_mode == "IMP" )
     {
         u8 accumulator = GetAccumulator();
 
@@ -1781,7 +1896,8 @@ void CPU::ROL( u16 address )
     }
     else
     {
-        u8 const value = Read( address );
+        u8 const value = ReadAndTick( address );
+        Tick(); // dummy write
 
         // Set the carry flag if bit 7 is set
         ( value & 0b10000000 ) != 0 ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
@@ -1793,7 +1909,7 @@ void CPU::ROL( u16 address )
         SetZeroAndNegativeFlags( result );
 
         // Write the result back to memory
-        Write( address, result );
+        WriteAndTick( address, result );
     }
 }
 
@@ -1812,7 +1928,7 @@ void CPU::ROR( u16 address )
 
     const u8 carry = IsFlagSet( Status::Carry ) ? 1 : 0;
 
-    if ( _imp )
+    if ( _addr_mode == "IMP" )
     { // implied mode
         u8 accumulator = GetAccumulator();
 
@@ -1833,7 +1949,8 @@ void CPU::ROR( u16 address )
     }
     else
     { // Memory mode
-        u8 const value = Read( address );
+        u8 const value = ReadAndTick( address );
+        Tick(); // simulate dummy write
 
         // Set the carry flag if bit 0 is set
         ( value & 0b00000001 ) != 0 ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
@@ -1845,7 +1962,7 @@ void CPU::ROR( u16 address )
         SetZeroAndNegativeFlags( result );
 
         // Write the result back to memory
-        Write( address, result );
+        WriteAndTick( address, result );
     }
 }
 
@@ -1870,6 +1987,7 @@ void CPU::JSR( u16 address )
      *   JSR Absolute: 20(6)
      */
     u16 const return_address = _pc - 1;
+    Tick(); // Additional read here, probably for timing purposes
     StackPush( ( return_address >> 8 ) & 0xFF );
     StackPush( return_address & 0xFF );
     _pc = address;
@@ -1887,7 +2005,9 @@ void CPU::RTS( const u16 address )
     u16 const low = StackPop();
     u16 const high = StackPop();
     _pc = ( high << 8 ) | low;
+    Tick(); // Account for reading the new address
     _pc++;
+    Tick(); // Account for reading the next pc value
 }
 
 void CPU::RTI( const u16 address )
@@ -1907,6 +2027,7 @@ void CPU::RTI( const u16 address )
     u16 const low = StackPop();
     u16 const high = StackPop();
     _pc = ( high << 8 ) | low;
+    Tick(); // Account for reading the new address
 }
 
 void CPU::BRK( const u16 address )
@@ -1916,20 +2037,24 @@ void CPU::BRK( const u16 address )
      * from stack
      *   Usage and cycles:
      *   BRK: 00(7)
+     * Cycles:
+     *   Read opcode: 1, Read padding byte: 1
+     *   Push PC(2): 2, Push status(1): 1
+     *   Read vector low: 1, Read vector high: 1
      */
     (void) address;
     _pc++; // padding byte
 
     // Push pc to the stack
-    StackPush( _pc >> 8 );
-    StackPush( _pc & 0x00FF );
+    StackPush( _pc >> 8 );     // 1 cycle
+    StackPush( _pc & 0x00FF ); // 1 cycle
 
     // Push status with break and unused flag set (ignored when popped)
     StackPush( _p | Break | Unused );
 
     // Set PC to the value at the interrupt vector (0xFFFE)
-    u16 const low = Read( 0xFFFE );
-    u16 const high = Read( 0xFFFF );
+    u16 const low = ReadAndTick( 0xFFFE );
+    u16 const high = ReadAndTick( 0xFFFF );
     _pc = ( high << 8 ) | low;
 
     // Set the interrupt disable flag
@@ -1951,7 +2076,7 @@ void CPU::AND( u16 address )
      *   AND Indirect X: 21(6)
      *   AND Indirect Y: 31(5+)
      */
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
     _a &= value;
     SetZeroAndNegativeFlags( _a );
 }
@@ -1972,7 +2097,7 @@ void CPU::ORA( const u16 address )
      *   ORA Indirect Y: 11(5+)
      */
 
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address ); // 1 cycle
     _a |= value;
     SetZeroAndNegativeFlags( _a );
 }
@@ -1992,7 +2117,7 @@ void CPU::EOR( const u16 address )
      *   EOR Indirect X: 41(6)
      *   EOR Indirect Y: 51(5+)
      */
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
     _a ^= value;
     SetZeroAndNegativeFlags( _a );
 }
@@ -2008,7 +2133,7 @@ void CPU::BIT( const u16 address )
      *   BIT Absolute: 2C(4)
      */
 
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
     SetZeroAndNegativeFlags( _a & value );
 
     // Set overflow flag to bit 6 of value
@@ -2084,6 +2209,7 @@ void CPU::JAM( const u16 address ) // NOLINT
      * Tom Harte tests include these, though, so for completeness, I'll add them
      */
     (void) address;
+    Tick();
     // Do nothing (undo the pc increment)
     _pc--;
 }
@@ -2103,7 +2229,11 @@ void CPU::SLO( const u16 address )
      *   SLO Indirect Y: 13(8)
      */
     CPU::ASL( address );
-    CPU::ORA( address );
+
+    // ORA is side effect, no cycles are spent
+    u8 const value = Read( address ); // 0 cycle
+    _a |= value;
+    SetZeroAndNegativeFlags( _a );
 }
 
 void CPU::RLA( const u16 address )
@@ -2121,7 +2251,11 @@ void CPU::RLA( const u16 address )
      *   RLA Indirect Y: 33(8)
      */
     CPU::ROL( address );
-    CPU::AND( address );
+
+    // Free side effect
+    u8 const value = Read( address ); // 0 cycle
+    _a &= value;
+    SetZeroAndNegativeFlags( _a );
 }
 
 void CPU::SRE( const u16 address )
@@ -2139,7 +2273,11 @@ void CPU::SRE( const u16 address )
      *   SRE Indirect Y: 53(8)
      */
     CPU::LSR( address );
-    CPU::EOR( address );
+
+    // Free side effect
+    u8 const value = Read( address ); // 0 cycle
+    _a ^= value;
+    SetZeroAndNegativeFlags( _a );
 }
 
 void CPU::RRA( const u16 address )
@@ -2171,7 +2309,7 @@ void CPU::SAX( const u16 address )
      *   SAX Indirect X: 83(6)
      *   SAX Absolute: 8F(4)
      */
-    Write( address, GetXRegister() & GetAccumulator() );
+    WriteAndTick( address, GetXRegister() & GetAccumulator() );
 }
 
 void CPU::LAX( const u16 address )
@@ -2187,7 +2325,7 @@ void CPU::LAX( const u16 address )
      *   LAX Indirect X: A3(6)
      *   LAX Indirect Y: B3(5+)
      */
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
     SetAccumulator( value );
     SetXRegister( value );
     SetZeroAndNegativeFlags( value );
@@ -2256,7 +2394,7 @@ void CPU::ARR( const u16 address )
      */
 
     // A & operand
-    u8 value = _a & Read( address );
+    u8 value = _a & ReadAndTick( address );
 
     // ROR
     u8 const carry_in = IsFlagSet( Status::Carry ) ? 0x80 : 0x00;
@@ -2298,7 +2436,7 @@ void CPU::LXA( const u16 address )
      *   LXA Immediate: AB(2)
      */
     u8 const magic_constant = 0xEE;
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
     u8 const result = ( ( _a | magic_constant ) & value );
     _a = result;
     _x = result;
@@ -2316,7 +2454,7 @@ void CPU::SBX( const u16 address )
      * Usage and cycles:
      *   SBX Immediate: CB (2 bytes, 2 cycles)
      */
-    u8 const  operand = Read( address );
+    u8 const  operand = ReadAndTick( address );
     u8 const  left = ( _a & _x );
     u16 const diff = static_cast<uint16_t>( left ) - static_cast<uint16_t>( operand );
     _x = static_cast<u8>( diff & 0xFF );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,8 +14,8 @@ int main()
         return 1;
     }
 
-    SDL_Window *window = SDL_CreateWindow( "NES Emulator", SDL_WINDOWPOS_CENTERED,
-                                           SDL_WINDOWPOS_CENTERED, 512, 480, SDL_WINDOW_SHOWN );
+    SDL_Window *window = SDL_CreateWindow( "NES Emulator", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                                           512, 480, SDL_WINDOW_SHOWN );
 
     if ( window == nullptr )
     {

--- a/src/ppu.cpp
+++ b/src/ppu.cpp
@@ -20,8 +20,8 @@ PPU::PPU( bool isDisabled ) : _isDisabled( isDisabled ) {}
 
     // Non-readable registers: 2000 (PPUCTRL), 2001 (PPUMASK), 2003 (OAMADDR), 2005 (PPUSCROLL),
     // 2006 (PPUADDR)
-    if ( _isDisabled || address == 0x2000 || address == 0x2001 || address == 0x2003 ||
-         address == 0x2005 || address == 0x2006 )
+    if ( _isDisabled || address == 0x2000 || address == 0x2001 || address == 0x2003 || address == 0x2005 ||
+         address == 0x2006 )
     {
         return 0x00;
     }
@@ -211,23 +211,4 @@ void PPU::Tick()
     //    - Incrementing horizontal/vertical scroll bits
     //    etc.
     // ---------------------------------------------
-}
-
-void PPU::SyncPPU( u64 current_cpu_cycles )
-{
-    // Edge where the cpu cycle overflows
-    // just kidding, that would take lifetimes for a 64 bit int..
-
-    if ( _isDisabled )
-    {
-        return;
-    }
-
-    u64 const cycles_since_sync = current_cpu_cycles - _lastSync;
-    u64 const ppu_cycles = cycles_since_sync * 3;
-    for ( u64 i = 0; i < ppu_cycles; i++ )
-    {
-        Tick();
-    }
-    _lastSync = current_cpu_cycles;
 }

--- a/tests/cpu_test.cpp
+++ b/tests/cpu_test.cpp
@@ -585,13 +585,11 @@ CPU_TEST( F8, SED, Implied, "f8.json" );
 ||       Illegal Opcodes      ||
 ################################
 */
-// Illegal - JAM (02, 12, 22, 32, 45, 52, 62, 72, 92, B2, D2, F2)
 CPU_TEST( 02, JAM, Implied, "02.json" );
 CPU_TEST( 12, JAM, Implied, "12.json" );
 CPU_TEST( 22, JAM, Implied, "22.json" );
 CPU_TEST( 32, JAM, Implied, "32.json" );
 CPU_TEST( 42, JAM, Implied, "42.json" );
-CPU_TEST( 45, JAM, Implied, "42.json" );
 CPU_TEST( 52, JAM, Implied, "52.json" );
 CPU_TEST( 62, JAM, Implied, "62.json" );
 CPU_TEST( 72, JAM, Implied, "72.json" );
@@ -599,9 +597,6 @@ CPU_TEST( 92, JAM, Implied, "92.json" );
 CPU_TEST( B2, JAM, Implied, "b2.json" );
 CPU_TEST( D2, JAM, Implied, "d2.json" );
 CPU_TEST( F2, JAM, Implied, "f2.json" );
-
-// Illegal - NOP (1A, 3A, 5A, 7A, DA, FA, 80, 82, 89, C2, E2, 04, 44, 64, 14, 34, 54, 74, D4,
-// F4, 0C, 1C, 3C, 5C, 7C, DC, FC)
 CPU_TEST( 1A, NOP, Implied, "1a.json" );
 CPU_TEST( 3A, NOP, Implied, "3a.json" );
 CPU_TEST( 5A, NOP, Implied, "5a.json" );
@@ -629,8 +624,6 @@ CPU_TEST( 5C, NOP, AbsoluteX, "5c.json" );
 CPU_TEST( 7C, NOP, AbsoluteX, "7c.json" );
 CPU_TEST( DC, NOP, AbsoluteX, "dc.json" );
 CPU_TEST( FC, NOP, AbsoluteX, "fc.json" );
-
-// Illegal - SLO: 07, 17, 0F, 1F, 1B, 03, 13
 CPU_TEST( 07, SLO, ZeroPage, "07.json" );
 CPU_TEST( 17, SLO, ZeroPageX, "17.json" );
 CPU_TEST( 0F, SLO, Absolute, "0f.json" );
@@ -638,8 +631,6 @@ CPU_TEST( 1F, SLO, AbsoluteX, "1f.json" );
 CPU_TEST( 1B, SLO, AbsoluteY, "1b.json" );
 CPU_TEST( 03, SLO, IndirectX, "03.json" );
 CPU_TEST( 13, SLO, IndirectY, "13.json" );
-
-// Illegal - RLA: 27, 37, 2F, 3F, 3B, 23, 33
 CPU_TEST( 27, RLA, ZeroPage, "27.json" );
 CPU_TEST( 37, RLA, ZeroPageX, "37.json" );
 CPU_TEST( 2F, RLA, Absolute, "2f.json" );
@@ -647,8 +638,6 @@ CPU_TEST( 3F, RLA, AbsoluteX, "3f.json" );
 CPU_TEST( 3B, RLA, AbsoluteY, "3b.json" );
 CPU_TEST( 23, RLA, IndirectX, "23.json" );
 CPU_TEST( 33, RLA, IndirectY, "33.json" );
-
-// Illegal - SRE: 47, 57, 4F, 5F, 5B, 43, 53
 CPU_TEST( 47, SRE, ZeroPage, "47.json" );
 CPU_TEST( 57, SRE, ZeroPageX, "57.json" );
 CPU_TEST( 4F, SRE, Absolute, "4f.json" );
@@ -656,8 +645,6 @@ CPU_TEST( 5F, SRE, AbsoluteX, "5f.json" );
 CPU_TEST( 5B, SRE, AbsoluteY, "5b.json" );
 CPU_TEST( 43, SRE, IndirectX, "43.json" );
 CPU_TEST( 53, SRE, IndirectY, "53.json" );
-
-// Illegal - RRA: 67, 77, 6F, 7F, 7B, 63, 73
 CPU_TEST( 67, RRA, ZeroPage, "67.json" );
 CPU_TEST( 77, RRA, ZeroPageX, "77.json" );
 CPU_TEST( 6F, RRA, Absolute, "6f.json" );
@@ -665,22 +652,16 @@ CPU_TEST( 7F, RRA, AbsoluteX, "7f.json" );
 CPU_TEST( 7B, RRA, AbsoluteY, "7b.json" );
 CPU_TEST( 63, RRA, IndirectX, "63.json" );
 CPU_TEST( 73, RRA, IndirectY, "73.json" );
-
-// Illegal - SAX: 87, 97, 8F, 83
 CPU_TEST( 87, SAX, ZeroPage, "87.json" );
 CPU_TEST( 97, SAX, ZeroPageY, "97.json" );
 CPU_TEST( 8F, SAX, Absolute, "8f.json" );
 CPU_TEST( 83, SAX, IndirectX, "83.json" );
-
-// Illegal - LAX: A7, B7, AF, BF, A3, B3
 CPU_TEST( A7, LAX, ZeroPage, "a7.json" );
 CPU_TEST( B7, LAX, ZeroPageY, "b7.json" );
 CPU_TEST( AF, LAX, Absolute, "af.json" );
 CPU_TEST( BF, LAX, AbsoluteY, "bf.json" );
 CPU_TEST( A3, LAX, IndirectX, "a3.json" );
 CPU_TEST( B3, LAX, IndirectY, "b3.json" );
-
-// Illegal - DCP: C7, D7, CF, DF, DB, C3, D3
 CPU_TEST( C7, DCP, ZeroPage, "c7.json" );
 CPU_TEST( D7, DCP, ZeroPageX, "d7.json" );
 CPU_TEST( CF, DCP, Absolute, "cf.json" );
@@ -688,8 +669,6 @@ CPU_TEST( DF, DCP, AbsoluteX, "df.json" );
 CPU_TEST( DB, DCP, AbsoluteY, "db.json" );
 CPU_TEST( C3, DCP, IndirectX, "c3.json" );
 CPU_TEST( D3, DCP, IndirectY, "d3.json" );
-
-// Illegal - ISC: E7, F7, EF, FF, FB, E3, F3
 CPU_TEST( E7, ISC, ZeroPage, "e7.json" );
 CPU_TEST( F7, ISC, ZeroPageX, "f7.json" );
 CPU_TEST( EF, ISC, Absolute, "ef.json" );
@@ -697,11 +676,13 @@ CPU_TEST( FF, ISC, AbsoluteX, "ff.json" );
 CPU_TEST( FB, ISC, AbsoluteY, "fb.json" );
 CPU_TEST( E3, ISC, IndirectX, "e3.json" );
 CPU_TEST( F3, ISC, IndirectY, "f3.json" );
-
-// ALR, ARR, ANE, SHA, TAS, LXA, LAS, SBX, USBC, SHY, SHX
-// 4B, 6B, 8B, 9F, 93, 9B, AB, BB, CB, EB, 9C, 9E
 CPU_TEST( 4B, ALR, Immediate, "4b.json" );
 CPU_TEST( 6B, ARR, Immediate, "6b.json" );
+CPU_TEST( EB, USBC, Immediate, "eb.json" );
+CPU_TEST( 0B, ANC, Immediate, "0b.json" );
+CPU_TEST( 2B, ANC, Immediate, "2b.json" );
+CPU_TEST( AB, LXA, Immediate, "ab.json" );
+CPU_TEST( CB, SBX, Immediate, "cb.json" );
 // CPU_TEST( 8B, ANE, Immediate, "8b.json" );
 // CPU_TEST( 9F, SHA, AbsoluteY, "9f.json" );
 // CPU_TEST( 93, SHA, IndirectY, "93.json" );
@@ -709,19 +690,8 @@ CPU_TEST( 6B, ARR, Immediate, "6b.json" );
 // CPU_TEST( AB, LXA, Immediate, "ab.json" );
 // CPU_TEST( BB, LAS, AbsoluteY, "bb.json" );
 // CPU_TEST( CB, SBX, Immediate, "cb.json" );
-CPU_TEST( EB, USBC, Immediate, "eb.json" );
 // CPU_TEST( 9C, SHY, AbsoluteX, "9c.json" );
 // CPU_TEST( 9E, SHX, AbsoluteY, "9e.json" );
-
-// Illegal - ANC: 0B, 2B
-CPU_TEST( 0B, ANC, Immediate, "0b.json" );
-CPU_TEST( 2B, ANC, Immediate, "2b.json" );
-
-// Illegal - LXA: AB
-CPU_TEST( AB, LXA, Immediate, "ab.json" );
-
-// Illegal - SBX: CB
-CPU_TEST( CB, SBX, Immediate, "cb.json" );
 
 /*
 ################################################################
@@ -754,7 +724,7 @@ void CPUTestFixture::RunTestCase( const json &testCase ) // NOLINT
     }
 
     // Fetch, decode, execute
-    cpu.Tick();
+    cpu.DecodeExecute();
 
     // Check final state
     bool               test_failed = false; // Track if any test has failed

--- a/tests/rom_test.cpp
+++ b/tests/rom_test.cpp
@@ -221,7 +221,7 @@ TEST( RomTests, Nestest )
             break;
         }
 
-        cpu.Tick(); // Run one CPU cycle
+        cpu.DecodeExecute(); // Run one CPU cycle
         line_index++;
     }
 
@@ -280,7 +280,7 @@ TEST( RomTests, InstructionTestV5 )
         // {
         //     cout << "made it here." << '\n';
         // }
-        cpu.Tick();
+        cpu.DecodeExecute();
         instr_count++;
 
         // Read test status from $6000


### PR DESCRIPTION
Cycles are spent with a global `Tick` method, which moves forward one cycle for the CPU, and three cycles for the PPU. These ticks are sprinkled at places where the real 6502 would (probably) spend a cycle, so mostly at reads and writes, and at a few edge case areas. 

The main purpose to do this was to allow the PPU to interrupt the CPU at any given point, which is now possible. 